### PR TITLE
Backend examples

### DIFF
--- a/tests/dash/app_dataframe_backend_paging.py
+++ b/tests/dash/app_dataframe_backend_paging.py
@@ -41,7 +41,7 @@ def layout():
                     {"name": i, "id": i, "deletable": True} for i in sorted(df.columns)
                 ],
                 pagination_settings={
-                    'displayed_pages': 2,
+                    'displayed_pages': 1,
                     'current_page': 0,
                     'page_size': PAGE_SIZE
                 },
@@ -71,7 +71,7 @@ def layout():
                     {"name": i, "id": i, "deletable": True} for i in sorted(df.columns)
                 ],
                 pagination_settings={
-                    'displayed_pages': 2,
+                    'displayed_pages': 1,
                     'current_page': 0,
                     'page_size': PAGE_SIZE
                 },
@@ -99,7 +99,7 @@ def layout():
                     {"name": i, "id": i, "deletable": True} for i in sorted(df.columns)
                 ],
                 pagination_settings={
-                    'displayed_pages': 2,
+                    'displayed_pages': 1,
                     'current_page': 0,
                     'page_size': PAGE_SIZE
                 },
@@ -138,7 +138,7 @@ def layout():
                     {"name": i, "id": i, "deletable": True} for i in sorted(df.columns)
                 ],
                 pagination_settings={
-                    'displayed_pages': 2,
+                    'displayed_pages': 1,
                     'current_page': 0,
                     'page_size': PAGE_SIZE
                 },
@@ -156,7 +156,7 @@ def layout():
                     {"name": i, "id": i, "deletable": True} for i in sorted(df.columns)
                 ],
                 pagination_settings={
-                    'displayed_pages': 2,
+                    'displayed_pages': 1,
                     'current_page': 0,
                     'page_size': PAGE_SIZE
                 },
@@ -306,7 +306,6 @@ def update_graph(pagination_settings, filtering_settings):
      Input(IDS["table-sorting-filtering"], "sorting_settings"),
      Input(IDS["table-sorting-filtering"], "filtering_settings")])
 def update_graph(pagination_settings, sorting_settings, filtering_settings):
-    print(filtering_settings)
     filtering_expressions = filtering_settings.split(' && ')
     dff = df
     for filter in filtering_expressions:


### PR DESCRIPTION
This creates several usage examples for backend paging, filtering, sorting (single and multi) and a final example that ties it together with a graph.

Overall, these features look good. A few improvements came to mind:
- Backend filtering shouldn't have to use the same query language as front-end. Users should be able to write their own backend DSLs. We could make this optional by providing a flag (`filtering_validate_expression=False`)
- We should start thinking about row IDs soon. I'd like to tie these backend examples in with `selected_rows` so that I could filter my dataset, graph a few rows through a selection, then filter my dataset again, select another set of rows, and see those rows appended in my graph.
- Filtering might be easier in the backend if the data was structured like `[{'column': 'lifeExp', 'expression': '> 5'}]`
- However, we should keep in mind that we might add a richer filtering UI in the front-end with even more structure.
- It's not clear to me what `displayed_pages` does.

I also intentionally left out the combination of "backend paging + front-end sorting" as I think that it just leads to confusion by the end-user. In other words, we should discourage this behaviour by leaving it undocumented.

Am I missing any functionality here? 

Besides those remarks above, I don't think there is any other things to fill out for this section.

@cldougl - am I missing any examples here?

@Marc-Andre-Rivet @valentijnnieman - do these examples look right? Am I missing anything?