### PR TITLE
app_sizing width examples in Dash Table

### DIFF
--- a/tests/dash/app_sizing.py
+++ b/tests/dash/app_sizing.py
@@ -383,8 +383,8 @@ def layout():
                 section_title("Dash Table - Vertical Scrolling with Max Height"),
                 dash_table.Table(
                     id="dt-vert-scroll-max-height",
-                    dataframe=df_long.to_dict("rows"),
-                    columns=[{"name": i, "id": i} for i in df_long.columns],
+                    dataframe=df.to_dict("rows"),
+                    columns=[{"name": i, "id": i} for i in df.columns],
                     table_style=[{
                         'selector': '.dash-spreadsheet',
                         'rule': 'max-height: 300px; overflow: scroll;'
@@ -394,8 +394,8 @@ def layout():
                 section_title("Dash Table - Vertical Scrolling with Height"),
                 dash_table.Table(
                     id="dt-vert-scroll",
-                    dataframe=df_long.to_dict("rows"),
-                    columns=[{"name": i, "id": i} for i in df_long.columns],
+                    dataframe=df.to_dict("rows"),
+                    columns=[{"name": i, "id": i} for i in df.columns],
                     table_style=[{
                         'selector': '.dash-spreadsheet',
                         'rule': 'height: 300px; overflow: scroll;'


### PR DESCRIPTION
Hey, here's a first stab at examples of setting widths in Dash Table. Not all of them work, I'm not sure if it's because something isn't working or if it's because I didn't do it the right way / didn't use the right prop, so let me know! I took the liberty of adding the examples from #116 so I could move quickly on that, sorry if that's causing issues somehow. The last example, `Dash Table - Alignment` isn't there because I wasn't sure what that should be.

Closes #114 