### PR TITLE
Fix table tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
                 name: Install requirements
                 command: |
                     . venv/bin/activate
+                    pip install -e .
                     pip install -r requirements-base.txt --quiet
                     pip install -r requirements-v0.txt --quiet
-                    pip install -e .
 
             - run:
                 name: Run build:js
@@ -86,9 +86,9 @@ jobs:
                 name: Install requirements
                 command: |
                     . venv/bin/activate
+                    pip install -e .
                     pip install -r requirements-base.txt --quiet
                     pip install -r requirements-v1.txt --quiet
-                    pip install -e .
 
             - run:
                 name: Run build:js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
                     . venv/bin/activate
                     pip install -r requirements-base.txt --quiet
                     pip install -r requirements-v0.txt --quiet
+                    pip install -e .
 
             - run:
                 name: Run build:js
@@ -87,6 +88,7 @@ jobs:
                     . venv/bin/activate
                     pip install -r requirements-base.txt --quiet
                     pip install -r requirements-v1.txt --quiet
+                    pip install -e .
 
             - run:
                 name: Run build:js


### PR DESCRIPTION
`dash` pulling other `dash-*` installs prevents the table tests from running correctly as the latest production build is used instead of the branch test build.

Correct test run here: https://circleci.com/gh/plotly/dash-table/tree/pip-local-packages