### PR TITLE
Upgrade core js

### DIFF
--- a/.config/webpack/base.js
+++ b/.config/webpack/base.js
@@ -8,11 +8,13 @@ module.exports = (options = {}) => {
     const babel = options.babel || undefined;
     const preprocessor = options.preprocessor || {};
     const mode = options.mode || 'development';
+    const ts = options.ts || {};
 
     console.log('********** Webpack Environment Overrides **********');
     console.log('Preprocessor', JSON.stringify(preprocessor));
     console.log('mode', mode);
     console.log('babel', JSON.stringify(babel));
+    console.log('ts', JSON.stringify(ts));
 
     return {
         entry: {
@@ -57,7 +59,7 @@ module.exports = (options = {}) => {
                     exclude: /node_modules/,
                     use: [
                         { loader: 'babel-loader', options: babel },
-                        { loader: 'ts-loader' },
+                        { loader: 'ts-loader', options: ts },
                         { loader: 'webpack-preprocessor', options: JSON.stringify(preprocessor) }
                     ]
                 },

--- a/.config/webpack/base.js
+++ b/.config/webpack/base.js
@@ -4,10 +4,15 @@ const packagejson = require('./../../package.json');
 
 const dashLibraryName = packagejson.name.replace(/-/g, '_');
 
-module.exports = (preprocessor = {}, mode = 'development') => {
+module.exports = (options = {}) => {
+    const babel = options.babel || undefined;
+    const preprocessor = options.preprocessor || {};
+    const mode = options.mode || 'development';
+
     console.log('********** Webpack Environment Overrides **********');
     console.log('Preprocessor', JSON.stringify(preprocessor));
     console.log('mode', mode);
+    console.log('babel', JSON.stringify(babel));
 
     return {
         entry: {
@@ -50,13 +55,19 @@ module.exports = (preprocessor = {}, mode = 'development') => {
                 {
                     test: /\.ts(x?)$/,
                     exclude: /node_modules/,
-                    loader: `babel-loader!ts-loader!webpack-preprocessor?${JSON.stringify(preprocessor)}`
+                    use: [
+                        { loader: 'babel-loader', options: babel },
+                        { loader: 'ts-loader' },
+                        { loader: 'webpack-preprocessor', options: JSON.stringify(preprocessor) }
+                    ]
                 },
                 {
                     test: /\.js$/,
                     exclude: /node_modules/,
-                    loader: `babel-loader!webpack-preprocessor?${JSON.stringify(preprocessor)}`
-
+                    use: [
+                        { loader: 'babel-loader', options: babel },
+                        { loader: 'webpack-preprocessor', options: JSON.stringify(preprocessor) }
+                    ]
                 },
                 {
                     test: /\.css$/,

--- a/.storybook/babel.config.js
+++ b/.storybook/babel.config.js
@@ -1,0 +1,9 @@
+const presets = [
+    ['@babel/env', {
+        useBuiltIns: 'entry',
+        corejs: 3
+    }],
+    '@babel/preset-react'
+];
+
+module.exports = { presets };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,7 @@
-let config = require('./../webpack.config.js');
+let babel = require('./babel.config.js');
+let config = require('./../.config/webpack/base.js')({
+    babel
+});
 
 config.externals = {};
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ const presets = [
             ]
         },
         useBuiltIns: 'usage',
-        corejs: 2
+        corejs: 3
     }],
     '@babel/preset-react'
 ];

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/react-dom": "^16.8.4",
     "@types/react-select": "^1.3.4",
     "babel-loader": "^8.0.5",
-    "core-js": "^2.6.5",
+    "core-js": "^3.0.1",
     "css-loader": "^2.1.1",
     "cypress": "^3.2.0",
     "d3-format": "^1.3.2",

--- a/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
+++ b/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
@@ -60,7 +60,7 @@ function modifyLex(config: SingleColumnConfig, res: ILexerResult) {
     return res;
 }
 
-type SingleColumnConfig = RequiredPluck<IVisibleColumn, 'id'> & OptionalPluck<IVisibleColumn, 'type'>;
+export type SingleColumnConfig = RequiredPluck<IVisibleColumn, 'id'> & OptionalPluck<IVisibleColumn, 'type'>;
 
 export default class SingleColumnSyntaxTree extends SyntaxTree {
     constructor(query: string, config: SingleColumnConfig) {

--- a/tests/cypress/tests/unit/edges_test.ts
+++ b/tests/cypress/tests/unit/edges_test.ts
@@ -143,12 +143,7 @@ describe('data edges', () => {
             ],
             [{
                 style: { border: '1px solid green' },
-                checksColumn: () => true,
-                checksFilter: () => true,
-                checksRow: () => true,
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' },

--- a/tests/cypress/tests/unit/edges_test.ts
+++ b/tests/cypress/tests/unit/edges_test.ts
@@ -1,6 +1,15 @@
 import dataEdges from 'dash-table/derived/edges/data';
 import Environment from 'core/environment';
 
+const converter = {
+    checksColumn: () => true,
+    checksFilter: () => true,
+    checksRow: () => true,
+    matchesColumn: () => true,
+    matchesFilter: () => true,
+    matchesRow: () => true
+};
+
 describe('data edges', () => {
     const edgesFn = dataEdges();
 
@@ -134,6 +143,9 @@ describe('data edges', () => {
             ],
             [{
                 style: { border: '1px solid green' },
+                checksColumn: () => true,
+                checksFilter: () => true,
+                checksRow: () => true,
                 matchesColumn: () => true,
                 matchesFilter: () => true,
                 matchesRow: () => true
@@ -181,9 +193,7 @@ describe('data edges', () => {
             ],
             [{
                 style: { borderLeft: '1px solid green', borderTop: '1px solid darkgreen' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' },
@@ -234,14 +244,10 @@ describe('data edges', () => {
             ],
             [{
                 style: { borderLeft: '1px solid green' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }, {
                 style: { borderRight: '1px solid darkgreen' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' }
@@ -271,14 +277,10 @@ describe('data edges', () => {
             ],
             [{
                 style: { borderRight: '1px solid darkgreen' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }, {
                 style: { borderLeft: '1px solid green' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' }
@@ -308,14 +310,10 @@ describe('data edges', () => {
             ],
             [{
                 style: { borderLeft: '1px solid darkgreen' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }, {
                 style: { border: '1px solid green' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' }
@@ -357,14 +355,10 @@ describe('data edges', () => {
             ],
             [{
                 style: { border: '1px solid green' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }, {
                 style: { borderLeft: '1px solid darkgreen' },
-                matchesColumn: () => true,
-                matchesFilter: () => true,
-                matchesRow: () => true
+                ...converter
             }],
             [
                 { id: 1, name: 'a' }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,6 +1,8 @@
-module.exports = require('./.config/webpack/base.js')(
-    {
+const options = {
+    preprocessor: {
         definitions: ['DEV']
     },
-    'development'
-);
+    mode: 'development'
+};
+
+module.exports = require('./.config/webpack/base.js')(options);

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,4 +1,7 @@
 const options = {
+    ts: {
+        transpileOnly: true
+    },
     preprocessor: {
         definitions: ['TEST', 'TEST_COPY_PASTE']
     },
@@ -6,11 +9,5 @@ const options = {
 };
 
 const config = require('./.config/webpack/base.js')(options);
-
-config.module.rules.forEach(rule => {
-    if (rule.loader) {
-        rule.loader = rule.loader.replace('ts-loader', `ts-loader?${JSON.stringify({ transpileOnly: true })}`);
-    }
-});
 
 module.exports = config;

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,9 +1,11 @@
-const config = require('./.config/webpack/base.js')(
-    {
+const options = {
+    preprocessor: {
         definitions: ['TEST', 'TEST_COPY_PASTE']
     },
-    'development'
-);
+    mode: 'development'
+};
+
+const config = require('./.config/webpack/base.js')(options);
 
 config.module.rules.forEach(rule => {
     if (rule.loader) {


### PR DESCRIPTION
Keeping up with the latest and greatest of various dependencies. Been preventing this one from updating through the renovate bot for a while now as it causes a bunch of issues in the tests.

What's the point? Core-js is a library that polyfills newer ES201x functionalities into things the `@babel/env` target browsers will all be able to use.

Fixing all of those here!