### PR TITLE
Optimize utility functions

### DIFF
--- a/src/core/comparer.ts
+++ b/src/core/comparer.ts
@@ -1,29 +1,25 @@
-function isPlainObject(candidate: any) {
-    return candidate !== undefined &&
-        candidate !== null &&
-        typeof candidate === 'object' &&
-        candidate.constructor === Object;
-}
-
-export function isEqual(obj1: object, obj2: object, deep: boolean = false) {
+export function isEqual(obj1: object, obj2: object) {
     return obj1 === obj2 || isEqualArgs(
         Object.values(obj1),
-        Object.values(obj2),
-        deep
+        Object.values(obj2)
     );
 }
 
-export function isEqualArgs(args1: any[] | null, args2: any[], deep: boolean = false): boolean {
-    return (
-        !!args1 &&
-        args1.length === args2.length &&
-        !!args1.every((arg1, index) => {
-            const arg2 = args2[index];
+export function isEqualArgs(args1: any[] | null, args2: any[]): boolean {
+    if (!args1) {
+        return false;
+    }
 
-            return arg1 === arg2 || (deep && (
-                (Array.isArray(arg1) && Array.isArray(arg2) && isEqualArgs(arg1, arg2, deep)) ||
-                (isPlainObject(arg1) && isPlainObject(arg2) && isEqual(arg1, arg2, deep))
-            ));
-        })
-    );
+    const _args1_ = args1.length;
+    if (_args1_ !== args2.length) {
+        return false;
+    }
+
+    for (let i = 0; i < _args1_; ++i) {
+        if (args1[i] !== args2[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/src/core/math/arrayZipMap.ts
+++ b/src/core/math/arrayZipMap.ts
@@ -1,24 +1,34 @@
-import * as R from 'ramda';
-
 type Array<T> = T[];
 
 export function arrayMap<T1, TR>(
     a1: Array<T1>,
     cb: (d1: T1, i: number) => TR
-) {
-    const mapArray = R.addIndex<T1, TR>(R.map);
+): Array<TR> {
+    const _a1_ = a1.length;
 
-    return mapArray((iValue, i) => cb(iValue, i), a1);
+    const res: Array<TR> = [];
+
+    for (let i = 0; i < _a1_; ++i) {
+        res.push(cb(a1[i], i));
+    }
+
+    return res;
 }
 
 export function arrayMap2<T1, T2, TR>(
     a1: Array<T1>,
     a2: Array<T2>,
     cb: (d1: T1, d2: T2, i: number) => TR
-) {
-    const mapArray = R.addIndex<T1, TR>(R.map);
+): Array<TR> {
+    const _a1_ = a1.length;
 
-    return mapArray((iValue, i) => cb(iValue, a2[i], i), a1);
+    const res: Array<TR> = [];
+
+    for (let i = 0; i < _a1_; ++i) {
+        res.push(cb(a1[i], a2[i], i));
+    }
+
+    return res;
 }
 
 export function arrayMap3<T1, T2, T3, TR>(
@@ -26,11 +36,16 @@ export function arrayMap3<T1, T2, T3, TR>(
     a2: Array<T2>,
     a3: Array<T3>,
     cb: (d1: T1, d2: T2, d3: T3, i: number) => TR
-) {
-    const mapArray = R.addIndex<T1, TR>(R.map);
+): Array<TR> {
+    const _a1_ = a1.length;
 
-    return mapArray((iValue, i) => cb(iValue, a2[i], a3[i], i), a1);
+    const res: Array<TR> = [];
 
+    for (let i = 0; i < _a1_; ++i) {
+        res.push(cb(a1[i], a2[i], a3[i], i));
+    }
+
+    return res;
 }
 
 export function arrayMapN<TR>(
@@ -40,7 +55,13 @@ export function arrayMapN<TR>(
     const a1 = arrays.slice(0, 1);
     const as = arrays.slice(1);
 
-    const mapArray = R.addIndex<any, TR>(R.map);
+    const _a1_ = a1.length;
 
-    return mapArray((iValue, i) => cb(i, [iValue, ...as.map(a => a[i])]), a1);
+    const res: Array<TR> = [];
+
+    for (let i = 0; i < _a1_; ++i) {
+        res.push(cb(i, a1[i], ...as.map(a => a[i])));
+    }
+
+    return res;
 }

--- a/src/core/math/arrayZipMap.ts
+++ b/src/core/math/arrayZipMap.ts
@@ -6,10 +6,10 @@ export function arrayMap<T1, TR>(
 ): Array<TR> {
     const _a1_ = a1.length;
 
-    const res: Array<TR> = [];
+    const res: Array<TR> = new Array<TR>(_a1_);
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(fn(a1[i], i));
+        res[i] = fn(a1[i], i);
     }
 
     return res;
@@ -22,10 +22,10 @@ export function arrayMap2<T1, T2, TR>(
 ): Array<TR> {
     const _a1_ = a1.length;
 
-    const res: Array<TR> = [];
+    const res: Array<TR> = new Array<TR>(_a1_);
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(fn(a1[i], a2[i], i));
+        res[i] = fn(a1[i], a2[i], i);
     }
 
     return res;
@@ -39,10 +39,10 @@ export function arrayMap3<T1, T2, T3, TR>(
 ): Array<TR> {
     const _a1_ = a1.length;
 
-    const res: Array<TR> = [];
+    const res: Array<TR> = new Array<TR>(_a1_);
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(fn(a1[i], a2[i], a3[i], i));
+        res[i] = fn(a1[i], a2[i], a3[i], i);
     }
 
     return res;
@@ -57,10 +57,10 @@ export function arrayMapN<TR>(
 
     const _a1_ = a1.length;
 
-    const res: Array<TR> = [];
+    const res: Array<TR> = new Array<TR>(_a1_);
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(fn(i, a1[i], ...as.map(a => a[i])));
+        res[i] = fn(i, a1[i], ...as.map(a => a[i]));
     }
 
     return res;

--- a/src/core/math/arrayZipMap.ts
+++ b/src/core/math/arrayZipMap.ts
@@ -2,14 +2,14 @@ type Array<T> = T[];
 
 export function arrayMap<T1, TR>(
     a1: Array<T1>,
-    cb: (d1: T1, i: number) => TR
+    fn: (d1: T1, i: number) => TR
 ): Array<TR> {
     const _a1_ = a1.length;
 
     const res: Array<TR> = [];
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(cb(a1[i], i));
+        res.push(fn(a1[i], i));
     }
 
     return res;
@@ -18,14 +18,14 @@ export function arrayMap<T1, TR>(
 export function arrayMap2<T1, T2, TR>(
     a1: Array<T1>,
     a2: Array<T2>,
-    cb: (d1: T1, d2: T2, i: number) => TR
+    fn: (d1: T1, d2: T2, i: number) => TR
 ): Array<TR> {
     const _a1_ = a1.length;
 
     const res: Array<TR> = [];
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(cb(a1[i], a2[i], i));
+        res.push(fn(a1[i], a2[i], i));
     }
 
     return res;
@@ -35,21 +35,21 @@ export function arrayMap3<T1, T2, T3, TR>(
     a1: Array<T1>,
     a2: Array<T2>,
     a3: Array<T3>,
-    cb: (d1: T1, d2: T2, d3: T3, i: number) => TR
+    fn: (d1: T1, d2: T2, d3: T3, i: number) => TR
 ): Array<TR> {
     const _a1_ = a1.length;
 
     const res: Array<TR> = [];
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(cb(a1[i], a2[i], a3[i], i));
+        res.push(fn(a1[i], a2[i], a3[i], i));
     }
 
     return res;
 }
 
 export function arrayMapN<TR>(
-    cb: (i: number, ...args: any[]) => TR,
+    fn: (i: number, ...args: any[]) => TR,
     ...arrays: (any[])[]
 ) {
     const a1 = arrays.slice(0, 1);
@@ -60,7 +60,7 @@ export function arrayMapN<TR>(
     const res: Array<TR> = [];
 
     for (let i = 0; i < _a1_; ++i) {
-        res.push(cb(i, a1[i], ...as.map(a => a[i])));
+        res.push(fn(i, a1[i], ...as.map(a => a[i])));
     }
 
     return res;

--- a/src/core/math/matrixZipMap.ts
+++ b/src/core/math/matrixZipMap.ts
@@ -1,65 +1,98 @@
-import * as R from 'ramda';
-
 type Matrix<T> = T[][];
 
-export const shallowClone: <T>(
+export function shallowClone<T>(
     m: Matrix<T>
-) => Matrix<T> = R.map(row => row.slice(0));
+): Matrix<T> {
+    const res = [];
 
-export const traverse2 = <T1, T2, TR>(
+    for (let i = 0; i < m.length; ++i) {
+        res.push(m[i].slice(0));
+    }
+
+    return res;
+}
+
+export function traverse2<T1, T2>(
+    a1: T1[],
+    a2: T2[],
+    fn: (d1: T1, d2: T2, i1: number, i2: number) => void
+) {
+    const _a1_ = a1.length;
+    const _a2_ = a2.length;
+
+    for (let i1 = 0; i1 < _a1_; ++i1) {
+        for (let i2 = 0; i2 < _a2_; ++i2) {
+            fn(a1[i1], a2[i2], i1, i2);
+        }
+    }
+}
+
+export function traverseMap2<T1, T2, TR>(
     a1: T1[],
     a2: T2[],
     fn: (d1: T1, d2: T2, i1: number, i2: number) => TR
-) => R.addIndex<T1>(R.forEach)((d1, i1) =>
-    R.addIndex<T2>(R.forEach)((d2, i2) =>
-        fn(d1, d2, i1, i2),
-        a2),
-    a1);
+): Matrix<TR> {
+    const _a1_ = a1.length;
+    const _a2_ = a2.length;
 
-export const traverseMap2 = <T1, T2, TR>(
-    a1: T1[],
-    a2: T2[],
-    fn: (d1: T1, d2: T2, i1: number, i2: number) => TR
-): Matrix<TR> => R.addIndex<T1, TR[]>(R.map)((d1, i1) =>
-    R.addIndex<T2, TR>(R.map)((d2, i2) =>
-        fn(d1, d2, i1, i2),
-        a2),
-    a1);
+    const res: Matrix<TR> = [];
+
+    for (let i1 = 0; i1 < _a1_; ++i1) {
+        const row = [];
+        for (let i2 = 0; i2 < _a2_; ++i2) {
+            row.push(fn(a1[i1], a2[i2], i1, i2));
+        }
+
+        res.push(row);
+    }
+
+    return res;
+}
 
 export function matrixMap<T1, TR>(
     m1: Matrix<T1>,
     cb: (d1: T1, i: number, j: number) => TR
 ) {
-    const mapMatrix = R.addIndex<T1[], TR[]>(R.map);
-    const mapRow = R.addIndex<T1, TR>(R.map);
+    const res: Matrix<TR> = [];
 
-    return mapMatrix((iRow, i) =>
-        mapRow(
-            (ijValue, j) => cb(ijValue, i, j),
-            iRow
-        ), m1
-    );
+    for (let i = 0; i < m1.length; ++i) {
+        let row = [];
+        for (let j = 0; j < m1[i].length; ++j) {
+            row.push(cb(
+                m1[i][j],
+                i,
+                j
+            ));
+        }
+
+        res.push(row);
+    }
+
+    return res;
 }
 
 export function matrixMap2<T1, T2, TR>(
     m1: Matrix<T1>,
     m2: Matrix<T2> | undefined,
     cb: (d1: T1, d2: T2 | undefined, i: number, j: number) => TR
-) {
-    const mapMatrix = R.addIndex<T1[], TR[]>(R.map);
-    const mapRow = R.addIndex<T1, TR>(R.map);
+): Matrix<TR> {
+    const res: Matrix<TR> = [];
 
-    return mapMatrix((iRow, i) =>
-        mapRow(
-            (ijValue, j) => cb(
-                ijValue,
+    for (let i = 0; i < m1.length; ++i) {
+        let row = [];
+        for (let j = 0; j < m1[i].length; ++j) {
+            row.push(cb(
+                m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 i,
                 j
-            ),
-            iRow
-        ), m1
-    );
+            ));
+        }
+
+        res.push(row);
+    }
+
+    return res;
 }
 
 export function matrixMap3<T1, T2, T3, TR>(
@@ -67,22 +100,25 @@ export function matrixMap3<T1, T2, T3, TR>(
     m2: Matrix<T2> | undefined,
     m3: Matrix<T3> | undefined,
     cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, i: number, j: number) => TR
-) {
-    const mapMatrix = R.addIndex<T1[], TR[]>(R.map);
-    const mapRow = R.addIndex<T1, TR>(R.map);
+): Matrix<TR> {
+    const res: Matrix<TR> = [];
 
-    return mapMatrix((iRow, i) =>
-        mapRow(
-            (ijValue, j) => cb(
-                ijValue,
+    for (let i = 0; i < m1.length; ++i) {
+        let row = [];
+        for (let j = 0; j < m1[i].length; ++j) {
+            row.push(cb(
+                m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
                 i,
                 j
-            ),
-            iRow
-        ), m1
-    );
+            ));
+        }
+
+        res.push(row);
+    }
+
+    return res;
 }
 
 export function matrixMap4<T1, T2, T3, T4, TR>(
@@ -91,23 +127,26 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
     m3: Matrix<T3> | undefined,
     m4: Matrix<T4> | undefined,
     cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, d4: T4 | undefined, i: number, j: number) => TR
-) {
-    const mapMatrix = R.addIndex<T1[], TR[]>(R.map);
-    const mapRow = R.addIndex<T1, TR>(R.map);
+): Matrix<TR> {
+    const res: Matrix<TR> = [];
 
-    return mapMatrix((iRow, i) =>
-        mapRow(
-            (ijValue, j) => cb(
-                ijValue,
+    for (let i = 0; i < m1.length; ++i) {
+        let row = [];
+        for (let j = 0; j < m1[i].length; ++j) {
+            row.push(cb(
+                m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
                 m4 ? m4[i][j] : undefined,
                 i,
                 j
-            ),
-            iRow
-        ), m1
-    );
+            ));
+        }
+
+        res.push(row);
+    }
+
+    return res;
 }
 
 export function matrixMapN<TR>(
@@ -115,21 +154,21 @@ export function matrixMapN<TR>(
     m1: Matrix<any>,
     ...matrices: (any[][] | undefined)[]
 ) {
-    const mapMatrix = R.addIndex<any[], TR[]>(R.map);
-    const mapRow = R.addIndex<any, TR>(R.map);
+    const res: Matrix<TR> = [];
 
-    return mapMatrix((iRow, i) =>
-        mapRow(
-            (ijValue, j) => cb(
+    for (let i = 0; i < m1.length; ++i) {
+        let row = [];
+        for (let j = 0; j < m1[i].length; ++j) {
+            row.push(cb(
+                m1[i][j],
                 i,
                 j,
-                [
-                    ijValue,
-                    m1[i][j],
                 ...matrices.map(m => m ? m[i][j] : undefined)
-                ]
-            ),
-            iRow
-        ), m1
-    );
+            ));
+        }
+
+        res.push(row);
+    }
+
+    return res;
 }

--- a/src/core/math/matrixZipMap.ts
+++ b/src/core/math/matrixZipMap.ts
@@ -53,9 +53,11 @@ export function matrixMap<T1, TR>(
     m1: Matrix<T1>,
     cb: (d1: T1, i: number, j: number) => TR
 ) {
+    const _m1_ = m1.length;
+
     const res: Matrix<TR> = [];
 
-    for (let i = 0; i < m1.length; ++i) {
+    for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
             row.push(cb(
@@ -76,9 +78,11 @@ export function matrixMap2<T1, T2, TR>(
     m2: Matrix<T2> | undefined,
     cb: (d1: T1, d2: T2 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
+    const _m1_ = m1.length;
+
     const res: Matrix<TR> = [];
 
-    for (let i = 0; i < m1.length; ++i) {
+    for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
             row.push(cb(
@@ -101,9 +105,11 @@ export function matrixMap3<T1, T2, T3, TR>(
     m3: Matrix<T3> | undefined,
     cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
+    const _m1_ = m1.length;
+
     const res: Matrix<TR> = [];
 
-    for (let i = 0; i < m1.length; ++i) {
+    for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
             row.push(cb(
@@ -128,9 +134,11 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
     m4: Matrix<T4> | undefined,
     cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, d4: T4 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
+    const _m1_ = m1.length;
+
     const res: Matrix<TR> = [];
 
-    for (let i = 0; i < m1.length; ++i) {
+    for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
             row.push(cb(
@@ -154,9 +162,11 @@ export function matrixMapN<TR>(
     m1: Matrix<any>,
     ...matrices: (any[][] | undefined)[]
 ) {
+    const _m1_ = m1.length;
+
     const res: Matrix<TR> = [];
 
-    for (let i = 0; i < m1.length; ++i) {
+    for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
             row.push(cb(

--- a/src/core/math/matrixZipMap.ts
+++ b/src/core/math/matrixZipMap.ts
@@ -3,9 +3,11 @@ type Matrix<T> = T[][];
 export function shallowClone<T>(
     m: Matrix<T>
 ): Matrix<T> {
+    const _m_ = m.length;
+
     const res = [];
 
-    for (let i = 0; i < m.length; ++i) {
+    for (let i = 0; i < _m_; ++i) {
         res.push(m[i].slice(0));
     }
 
@@ -51,7 +53,7 @@ export function traverseMap2<T1, T2, TR>(
 
 export function matrixMap<T1, TR>(
     m1: Matrix<T1>,
-    cb: (d1: T1, i: number, j: number) => TR
+    fn: (d1: T1, i: number, j: number) => TR
 ) {
     const _m1_ = m1.length;
 
@@ -60,7 +62,7 @@ export function matrixMap<T1, TR>(
     for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
-            row.push(cb(
+            row.push(fn(
                 m1[i][j],
                 i,
                 j
@@ -76,7 +78,7 @@ export function matrixMap<T1, TR>(
 export function matrixMap2<T1, T2, TR>(
     m1: Matrix<T1>,
     m2: Matrix<T2> | undefined,
-    cb: (d1: T1, d2: T2 | undefined, i: number, j: number) => TR
+    fn: (d1: T1, d2: T2 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
@@ -85,7 +87,7 @@ export function matrixMap2<T1, T2, TR>(
     for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
-            row.push(cb(
+            row.push(fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 i,
@@ -103,7 +105,7 @@ export function matrixMap3<T1, T2, T3, TR>(
     m1: Matrix<T1>,
     m2: Matrix<T2> | undefined,
     m3: Matrix<T3> | undefined,
-    cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, i: number, j: number) => TR
+    fn: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
@@ -112,7 +114,7 @@ export function matrixMap3<T1, T2, T3, TR>(
     for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
-            row.push(cb(
+            row.push(fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
@@ -132,7 +134,7 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
     m2: Matrix<T2> | undefined,
     m3: Matrix<T3> | undefined,
     m4: Matrix<T4> | undefined,
-    cb: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, d4: T4 | undefined, i: number, j: number) => TR
+    fn: (d1: T1, d2: T2 | undefined, d3: T3 | undefined, d4: T4 | undefined, i: number, j: number) => TR
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
@@ -141,7 +143,7 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
     for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
-            row.push(cb(
+            row.push(fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
@@ -158,7 +160,7 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
 }
 
 export function matrixMapN<TR>(
-    cb: (i: number, j: number, ...args: any[]) => TR,
+    fn: (i: number, j: number, ...args: any[]) => TR,
     m1: Matrix<any>,
     ...matrices: (any[][] | undefined)[]
 ) {
@@ -169,7 +171,7 @@ export function matrixMapN<TR>(
     for (let i = 0; i < _m1_; ++i) {
         let row = [];
         for (let j = 0; j < m1[i].length; ++j) {
-            row.push(cb(
+            row.push(fn(
                 m1[i][j],
                 i,
                 j,

--- a/src/core/math/matrixZipMap.ts
+++ b/src/core/math/matrixZipMap.ts
@@ -5,10 +5,10 @@ export function shallowClone<T>(
 ): Matrix<T> {
     const _m_ = m.length;
 
-    const res = [];
+    const res: Matrix<T> = new Array<T[]>(_m_);
 
     for (let i = 0; i < _m_; ++i) {
-        res.push(m[i].slice(0));
+        res[i] = m[i].slice(0);
     }
 
     return res;
@@ -37,15 +37,16 @@ export function traverseMap2<T1, T2, TR>(
     const _a1_ = a1.length;
     const _a2_ = a2.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_a1_);
 
     for (let i1 = 0; i1 < _a1_; ++i1) {
-        const row = [];
+        const row = new Array<TR>(_a2_);
+
         for (let i2 = 0; i2 < _a2_; ++i2) {
-            row.push(fn(a1[i1], a2[i2], i1, i2));
+            row[i2] = fn(a1[i1], a2[i2], i1, i2);
         }
 
-        res.push(row);
+        res[i1] = row;
     }
 
     return res;
@@ -57,19 +58,21 @@ export function matrixMap<T1, TR>(
 ) {
     const _m1_ = m1.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_m1_);
 
     for (let i = 0; i < _m1_; ++i) {
-        let row = [];
-        for (let j = 0; j < m1[i].length; ++j) {
-            row.push(fn(
+        const _row_ = m1[i].length;
+        let row = new Array<TR>(_row_);
+
+        for (let j = 0; j < _row_; ++j) {
+            row[j] = fn(
                 m1[i][j],
                 i,
                 j
-            ));
+            );
         }
 
-        res.push(row);
+        res[i] = row;
     }
 
     return res;
@@ -82,20 +85,22 @@ export function matrixMap2<T1, T2, TR>(
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_m1_);
 
     for (let i = 0; i < _m1_; ++i) {
-        let row = [];
-        for (let j = 0; j < m1[i].length; ++j) {
-            row.push(fn(
+        const _row_ = m1[i].length;
+        let row = new Array<TR>(_row_);
+
+        for (let j = 0; j < _row_; ++j) {
+            row[j] = fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 i,
                 j
-            ));
+            );
         }
 
-        res.push(row);
+        res[i] = row;
     }
 
     return res;
@@ -109,21 +114,23 @@ export function matrixMap3<T1, T2, T3, TR>(
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_m1_);
 
     for (let i = 0; i < _m1_; ++i) {
-        let row = [];
-        for (let j = 0; j < m1[i].length; ++j) {
-            row.push(fn(
+        const _row_ = m1[i].length;
+        let row = new Array<TR>(_row_);
+
+        for (let j = 0; j < _row_; ++j) {
+            row[j] = fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
                 i,
                 j
-            ));
+            );
         }
 
-        res.push(row);
+        res[i] = row;
     }
 
     return res;
@@ -138,22 +145,24 @@ export function matrixMap4<T1, T2, T3, T4, TR>(
 ): Matrix<TR> {
     const _m1_ = m1.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_m1_);
 
     for (let i = 0; i < _m1_; ++i) {
-        let row = [];
-        for (let j = 0; j < m1[i].length; ++j) {
-            row.push(fn(
+        const _row_ = m1[i].length;
+        let row = new Array<TR>(_row_);
+
+        for (let j = 0; j < _row_; ++j) {
+            row[j] = fn(
                 m1[i][j],
                 m2 ? m2[i][j] : undefined,
                 m3 ? m3[i][j] : undefined,
                 m4 ? m4[i][j] : undefined,
                 i,
                 j
-            ));
+            );
         }
 
-        res.push(row);
+        res[i] = row;
     }
 
     return res;
@@ -166,20 +175,22 @@ export function matrixMapN<TR>(
 ) {
     const _m1_ = m1.length;
 
-    const res: Matrix<TR> = [];
+    const res: Matrix<TR> = new Array<TR[]>(_m1_);
 
     for (let i = 0; i < _m1_; ++i) {
-        let row = [];
-        for (let j = 0; j < m1[i].length; ++j) {
-            row.push(fn(
+        const _row_ = m1[i].length;
+        let row = new Array<TR>(_row_);
+
+        for (let j = 0; j < _row_; ++j) {
+            row[j] = fn(
                 m1[i][j],
                 i,
                 j,
                 ...matrices.map(m => m ? m[i][j] : undefined)
-            ));
+            );
         }
 
-        res.push(row);
+        res[i] = row;
     }
 
     return res;

--- a/src/dash-table/components/Table/index.tsx
+++ b/src/dash-table/components/Table/index.tsx
@@ -84,7 +84,7 @@ export default class Table extends Component<SanitizedAndDerivedProps, Standalon
         return R.any(key =>
             !DERIVED_REGEX.test(key) && props[key] !== nextProps[key],
             R.keysIn(props)
-        ) || !isEqual(state, nextState, false);
+        ) || !isEqual(state, nextState);
     }
 
     render() {

--- a/src/dash-table/derived/edges/index.ts
+++ b/src/dash-table/derived/edges/index.ts
@@ -1,27 +1,30 @@
-import * as R from 'ramda';
-
 import { BorderStyle, BORDER_PROPERTIES } from './type';
 import { IConvertedStyle } from '../style';
 import { Datum, IVisibleColumn } from 'dash-table/components/Table/props';
 import { matchesDataCell, matchesDataOpCell, matchesFilterCell, getFilterOpStyles, matchesHeaderCell, getHeaderOpStyles } from 'dash-table/conditional';
+import { traverse2 } from 'core/math/matrixZipMap';
 
 function resolveEdges(styles: IConvertedStyle[]): BorderStyle {
     let res: BorderStyle = {};
 
-    R.addIndex<IConvertedStyle>(R.forEach)((s, i) => R.forEach(p => {
-        const border = s.style[p] || s.style.border;
+    traverse2(
+        styles,
+        BORDER_PROPERTIES,
+        (s, p, i) => {
+            const border = s.style[p];
 
-        if (border) {
-            res[p] = [border, i];
+            if (border) {
+                res[p] = [border, i];
+            }
         }
-    }, BORDER_PROPERTIES), styles);
+    );
 
     return res;
 }
 
-export const getDataCellEdges = (datum: Datum, i: number, column: IVisibleColumn) => R.compose(resolveEdges, matchesDataCell(datum, i, column));
-export const getDataOpCellEdges = (datum: Datum, i: number) => R.compose(resolveEdges, matchesDataOpCell(datum, i));
-export const getFilterCellEdges = (column: IVisibleColumn) => R.compose(resolveEdges, matchesFilterCell(column));
-export const getFilterOpCellEdges = () => R.compose(resolveEdges, getFilterOpStyles);
-export const getHeaderCellEdges = (i: number, column: IVisibleColumn) => R.compose(resolveEdges, matchesHeaderCell(i, column));
-export const getHeaderOpCellEdges = (i: number) => R.compose(resolveEdges, getHeaderOpStyles(i));
+export const getDataCellEdges = (datum: Datum, i: number, column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveEdges(matchesDataCell(datum, i, column)(styles));
+export const getDataOpCellEdges = (datum: Datum, i: number) => (styles: IConvertedStyle[]) => resolveEdges(matchesDataOpCell(datum, i)(styles));
+export const getFilterCellEdges = (column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveEdges(matchesFilterCell(column)(styles));
+export const getFilterOpCellEdges = () => (styles: IConvertedStyle[]) => resolveEdges(getFilterOpStyles(styles));
+export const getHeaderCellEdges = (i: number, column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveEdges(matchesHeaderCell(i, column)(styles));
+export const getHeaderOpCellEdges = (i: number) => (styles: IConvertedStyle[]) => resolveEdges(getHeaderOpStyles(i)(styles));

--- a/src/dash-table/derived/edges/index.ts
+++ b/src/dash-table/derived/edges/index.ts
@@ -11,7 +11,7 @@ function resolveEdges(styles: IConvertedStyle[]): BorderStyle {
         styles,
         BORDER_PROPERTIES,
         (s, p, i) => {
-            const border = s.style[p];
+            const border = s.style[p] || s.style.border;
 
             if (border) {
                 res[p] = [border, i];

--- a/src/dash-table/derived/style/index.ts
+++ b/src/dash-table/derived/style/index.ts
@@ -130,17 +130,18 @@ export const derivedTableStyle = memoizeOneFactory(
 );
 
 export function resolveStyle(styles: IConvertedStyle[]): CSSProperties {
-    return R.mergeAll(
-        R.map<IConvertedStyle, CSSProperties>(
-            s => R.omit(BORDER_PROPERTIES_AND_FRAGMENTS, s.style),
-            styles
-        )
-    );
+    let res: CSSProperties = {};
+
+    for (let i = 0; i < styles.length; ++i) {
+        Object.assign(res, styles[i].style);
+    }
+
+    return R.omit(BORDER_PROPERTIES_AND_FRAGMENTS, res);
 }
 
-export const getDataCellStyle = (datum: Datum, i: number, column: IVisibleColumn) => R.compose(resolveStyle, matchesDataCell(datum, i, column));
-export const getDataOpCellStyle = (datum: Datum, i: number) => R.compose(resolveStyle, matchesDataOpCell(datum, i));
-export const getFilterCellStyle = (column: IVisibleColumn) => R.compose(resolveStyle, matchesFilterCell(column));
-export const getFilterOpCellStyle = () => R.compose(resolveStyle, getFilterOpStyles);
-export const getHeaderCellStyle = (i: number, column: IVisibleColumn) => R.compose(resolveStyle, matchesHeaderCell(i, column));
-export const getHeaderOpCellStyle = (i: number) => R.compose(resolveStyle, getHeaderOpStyles(i));
+export const getDataCellStyle = (datum: Datum, i: number, column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveStyle(matchesDataCell(datum, i, column)(styles));
+export const getDataOpCellStyle = (datum: Datum, i: number) => (styles: IConvertedStyle[]) => resolveStyle(matchesDataOpCell(datum, i)(styles));
+export const getFilterCellStyle = (column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveStyle(matchesFilterCell(column)(styles));
+export const getFilterOpCellStyle = () => (styles: IConvertedStyle[]) => resolveStyle(getFilterOpStyles(styles));
+export const getHeaderCellStyle = (i: number, column: IVisibleColumn) => (styles: IConvertedStyle[]) => resolveStyle(matchesHeaderCell(i, column)(styles));
+export const getHeaderOpCellStyle = (i: number) => (styles: IConvertedStyle[]) => resolveStyle(getHeaderOpStyles(i)(styles));

--- a/tslint.json
+++ b/tslint.json
@@ -80,6 +80,7 @@
         ],
         "ordered-imports": false,
         "prefer-const": false,
+        "prefer-for-of": false,
         "quotemark": [true, "single"],
         "space-before-function-paren": [false, "always"],
         "trailing-comma": [true, {


### PR DESCRIPTION
This does 2 things:

1. Optimize the utility functions (mostly removing Ramda for/map/addIndex in favor of native `for` loops)
This drops average render time from ~50ms down to ~35ms.

2. Optimize the previously optimized edges & styles calculations (https://github.com/plotly/dash-table/pull/465). This is done by removing Ramda where possible and through some other optimizations.
This drops the average render time from ~35ms to ~23ms.

Reflow and react internals remain unchanged with ~100ms and ~50ms per render respectively while table `render` itself is slashed in half. This only represents a ~10% improvement.

At this point ~45% (~10-10.5ms) of the table's `render` time is accounted for by cache busting / checks on memoized functions.