### PR TITLE
Fix sticky behavior in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 reset the filter for the affected column(s)
 
 ### Fixed
+[#259](https://github.com/plotly/dash-table/issues/259)
+- Fixed columns `sticky` on Safari
+
 [#491](https://github.com/plotly/dash-table/issues/491)
 - Fixed inconsistent behaviors when editing cell headers
 

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -257,6 +257,7 @@
                 flex: 0 0 auto;
                 left: 0;
                 position: sticky;
+                position:-webkit-sticky;
                 z-index: 400;
             }
 
@@ -434,6 +435,10 @@
 
     .dash-spreadsheet-inner th {
         background-color: rgb(250, 250, 250);
+    }
+
+    .dash-spreadsheet-inner td {
+        background-color: white;
     }
 
     .sort {


### PR DESCRIPTION
@alinastarkov found `-webkit-sticky`, just adding it and fixing a (would be) regression on fixed columns (when transparent) 