### PR TITLE
Issue 524 - Readonly dropdown column content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Additionally clearing the column will reset the filter for the affected column(s)
 
 [#318](https://github.com/plotly/dash-table/issues/318)
-- Headers are included when copying from the table to different 
-tabs and elsewhere. They are ignored when copying from the table onto itself and 
-between two tables within the same tab. 
+- Headers are included when copying from the table to different
+tabs and elsewhere. They are ignored when copying from the table onto itself and
+between two tables within the same tab.
 
 ### Changed
 [#497](https://github.com/plotly/dash-table/pull/497)
@@ -36,6 +36,9 @@ between two tables within the same tab.
 reset the filter for the affected column(s)
 
 ### Fixed
+[#524](https://github.com/plotly/dash-table/issues/524)
+- Fixed readonly dropdown cells content (display label, not value)
+
 [#491](https://github.com/plotly/dash-table/issues/491)
 - Fixed inconsistent behaviors when editing cell headers
 

--- a/demo/AppMode.ts
+++ b/demo/AppMode.ts
@@ -56,7 +56,14 @@ function getBaseTableProps(mock: IDataMock) {
             bbb: {
                 clearable: true,
                 options: ['Humid', 'Wet', 'Snowy', 'Tropical Beaches'].map(i => ({
-                    label: i,
+                    label: `label: ${i}`,
+                    value: i
+                }))
+            },
+            'bbb-readonly': {
+                clearable: true,
+                options: ['Humid', 'Wet', 'Snowy', 'Tropical Beaches'].map(i => ({
+                    label: `label: ${i}`,
                     value: i
                 }))
             }

--- a/demo/data.ts
+++ b/demo/data.ts
@@ -68,6 +68,7 @@ export const generateMockData = (rows: number) => unpackIntoColumnsAndData([
         id: 'bbb-readonly',
         name: ['', 'Weather', 'Climate-RO'],
         type: ColumnType.Text,
+        presentation: 'dropdown',
         editable: false,
         data: gendata(
             i => ['Humid', 'Wet', 'Snowy', 'Tropical Beaches'][i % 4],
@@ -86,6 +87,7 @@ export const generateMockData = (rows: number) => unpackIntoColumnsAndData([
         id: 'aaa-readonly',
         name: ['', 'Weather', 'Temperature-RO'],
         type: ColumnType.Numeric,
+        presentation: 'dropdown',
         editable: false,
         data: gendata(i => i + 1, rows)
     }

--- a/tests/cypress/tests/standalone/filtering_test.ts
+++ b/tests/cypress/tests/standalone/filtering_test.ts
@@ -12,7 +12,7 @@ describe(`filter special characters`, () => {
 
     it('can filter on special column id', () => {
         DashTable.getFilterById('b+bb').click();
-        DOM.focused.type(`Wet${Key.Enter}`);
+        DOM.focused.type(`label: Wet${Key.Enter}`);
 
         DashTable.getFilterById('c cc').click();
         DOM.focused.type(`gt 90${Key.Enter}`);
@@ -32,7 +32,7 @@ describe(`filter special characters`, () => {
 
         DashTable.getCellById(0, 'rows').within(() => cy.get('.dash-cell-value').should('have.html', '101'));
         DashTable.getCellById(1, 'rows').should('not.exist');
-        DashTable.getFilterById('b+bb').within(() => cy.get('input').should('have.value', 'Wet'));
+        DashTable.getFilterById('b+bb').within(() => cy.get('input').should('have.value', 'label: Wet'));
         DashTable.getFilterById('c cc').within(() => cy.get('input').should('have.value', 'gt 90'));
         DashTable.getFilterById('d:dd').within(() => cy.get('input').should('have.value', 'lt 12500'));
         DashTable.getFilterById('e-ee').within(() => cy.get('input').should('have.value', 'is prime'));
@@ -143,13 +143,13 @@ describe('filter', () => {
         DashTable.getFilterById('eee').click();
         DOM.focused.type('is prime');
         DashTable.getFilterById('bbb').click();
-        DOM.focused.type(`Wet`);
+        DOM.focused.type(`label: Wet`);
         DashTable.getFilterById('ccc').click();
 
         DashTable.getCellById(0, 'ccc').within(() => cy.get('.dash-cell-value').should('have.html', '101'));
         DashTable.getCellById(1, 'ccc').within(() => cy.get('.dash-cell-value').should('have.html', '109'));
 
-        DashTable.getFilterById('bbb').within(() => cy.get('input').should('have.value', 'Wet'));
+        DashTable.getFilterById('bbb').within(() => cy.get('input').should('have.value', 'label: Wet'));
         DashTable.getFilterById('ccc').within(() => cy.get('input').should('have.value', 'gt 100'));
         DashTable.getFilterById('ddd').within(() => cy.get('input').should('have.value', 'lt 20000'));
         DashTable.getFilterById('eee').within(() => cy.get('input').should('have.value', 'is prime'));

--- a/tests/cypress/tests/standalone/filtering_test.ts
+++ b/tests/cypress/tests/standalone/filtering_test.ts
@@ -12,7 +12,7 @@ describe(`filter special characters`, () => {
 
     it('can filter on special column id', () => {
         DashTable.getFilterById('b+bb').click();
-        DOM.focused.type(`label: Wet${Key.Enter}`);
+        DOM.focused.type(`Wet${Key.Enter}`);
 
         DashTable.getFilterById('c cc').click();
         DOM.focused.type(`gt 90${Key.Enter}`);
@@ -32,7 +32,7 @@ describe(`filter special characters`, () => {
 
         DashTable.getCellById(0, 'rows').within(() => cy.get('.dash-cell-value').should('have.html', '101'));
         DashTable.getCellById(1, 'rows').should('not.exist');
-        DashTable.getFilterById('b+bb').within(() => cy.get('input').should('have.value', 'label: Wet'));
+        DashTable.getFilterById('b+bb').within(() => cy.get('input').should('have.value', 'Wet'));
         DashTable.getFilterById('c cc').within(() => cy.get('input').should('have.value', 'gt 90'));
         DashTable.getFilterById('d:dd').within(() => cy.get('input').should('have.value', 'lt 12500'));
         DashTable.getFilterById('e-ee').within(() => cy.get('input').should('have.value', 'is prime'));
@@ -101,7 +101,7 @@ describe('filter', () => {
         DashTable.getFilterById('ccc').click();
 
         DashTable.getFilterById('bbb').within(() => cy.get('input').should('have.value', 'Tr'));
-        DashTable.getCellById(0, 'bbb-readonly').within(() => cy.get('.dash-cell-value').should('have.html', 'Tropical Beaches'));
+        DashTable.getCellById(0, 'bbb-readonly').within(() => cy.get('.dash-cell-value').should('have.html', 'label: Tropical Beaches'));
     });
 
     it('filters `Numeric` columns with `equal` without operator', () => {
@@ -143,13 +143,13 @@ describe('filter', () => {
         DashTable.getFilterById('eee').click();
         DOM.focused.type('is prime');
         DashTable.getFilterById('bbb').click();
-        DOM.focused.type(`label: Wet`);
+        DOM.focused.type(`Wet`);
         DashTable.getFilterById('ccc').click();
 
         DashTable.getCellById(0, 'ccc').within(() => cy.get('.dash-cell-value').should('have.html', '101'));
         DashTable.getCellById(1, 'ccc').within(() => cy.get('.dash-cell-value').should('have.html', '109'));
 
-        DashTable.getFilterById('bbb').within(() => cy.get('input').should('have.value', 'label: Wet'));
+        DashTable.getFilterById('bbb').within(() => cy.get('input').should('have.value', 'Wet'));
         DashTable.getFilterById('ccc').within(() => cy.get('input').should('have.value', 'gt 100'));
         DashTable.getFilterById('ddd').within(() => cy.get('input').should('have.value', 'lt 20000'));
         DashTable.getFilterById('eee').within(() => cy.get('input').should('have.value', 'is prime'));

--- a/tests/cypress/tests/standalone/readonly_sorting_test.ts
+++ b/tests/cypress/tests/standalone/readonly_sorting_test.ts
@@ -10,15 +10,25 @@ Object.values([AppMode.ReadOnly]).forEach(mode => {
         });
 
         it('can sort', () => {
-            DashTable.getCell(0, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Wet'));
-            DashTable.getCell(1, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Snowy'));
-            DashTable.getCell(2, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Tropical Beaches'));
-            DashTable.getCell(3, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Humid'));
+            DashTable.getCell(0, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Wet'));
+            DashTable.getCell(1, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Snowy'));
+            DashTable.getCell(2, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Tropical Beaches'));
+            DashTable.getCell(3, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+
+            DashTable.getCell(0, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Wet'));
+            DashTable.getCell(1, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Snowy'));
+            DashTable.getCell(2, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Tropical Beaches'));
+            DashTable.getCell(3, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
             cy.get('tr th.column-6 .sort').last().click();
-            DashTable.getCell(0, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Humid'));
-            DashTable.getCell(1, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Humid'));
-            DashTable.getCell(2, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Humid'));
-            DashTable.getCell(3, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'Humid'));
+            DashTable.getCell(0, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(1, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(2, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(3, 6).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+
+            DashTable.getCell(0, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(1, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(2, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(3, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
         });
     });
 });

--- a/tests/cypress/tests/standalone/readwrite_sorting_test.ts
+++ b/tests/cypress/tests/standalone/readwrite_sorting_test.ts
@@ -15,20 +15,20 @@ Object.values(ReadWriteModes).forEach(mode => {
             DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Tropical Beaches'));
             DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
 
-            DashTable.getCell(0, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Wet'));
-            DashTable.getCell(1, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Snowy'));
-            DashTable.getCell(2, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Tropical Beaches'));
-            DashTable.getCell(3, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(0, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Wet'));
+            DashTable.getCell(1, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Snowy'));
+            DashTable.getCell(2, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Tropical Beaches'));
+            DashTable.getCell(3, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
             cy.get('tr th.column-6 .sort').last().click();
             DashTable.getCell(0, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
             DashTable.getCell(1, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
             DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
             DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
 
-            DashTable.getCell(0, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
-            DashTable.getCell(1, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
-            DashTable.getCell(2, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
-            DashTable.getCell(3, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(0, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(1, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(2, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
+            DashTable.getCell(3, 7).within(() => cy.get('.dash-cell-value').should('have.html', 'label: Humid'));
         });
     });
 });

--- a/tests/cypress/tests/standalone/readwrite_sorting_test.ts
+++ b/tests/cypress/tests/standalone/readwrite_sorting_test.ts
@@ -10,15 +10,25 @@ Object.values(ReadWriteModes).forEach(mode => {
         });
 
         it('can sort', () => {
-            DashTable.getCell(0, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Wet'));
-            DashTable.getCell(1, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Snowy'));
-            DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Tropical Beaches'));
-            DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Humid'));
+            DashTable.getCell(0, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Wet'));
+            DashTable.getCell(1, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Snowy'));
+            DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Tropical Beaches'));
+            DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+
+            DashTable.getCell(0, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Wet'));
+            DashTable.getCell(1, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Snowy'));
+            DashTable.getCell(2, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Tropical Beaches'));
+            DashTable.getCell(3, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
             cy.get('tr th.column-6 .sort').last().click();
-            DashTable.getCell(0, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Humid'));
-            DashTable.getCell(1, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Humid'));
-            DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Humid'));
-            DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'Humid'));
+            DashTable.getCell(0, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(1, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(2, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(3, 6).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+
+            DashTable.getCell(0, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(1, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(2, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
+            DashTable.getCell(3, 7).within(() => cy.get('.Select-value-label').should('have.html', 'label: Humid'));
         });
     });
 });

--- a/tests/visual/percy-storybook/Dropdown.percy.tsx
+++ b/tests/visual/percy-storybook/Dropdown.percy.tsx
@@ -30,6 +30,48 @@ const columns2 = R.map(
 );
 
 storiesOf('DashTable/Dropdown', module)
+    .add('readonly dropdown shows label', () => <DataTable
+        setProps={setProps}
+        id='table'
+        data={data}
+        columns={columns}
+        editable={false}
+        dropdown={{
+            climate: {
+                options: R.map(
+                    i => ({ label: `label: ${i}`, value: i }),
+                    ['Sunny', 'Snowy', 'Rainy']
+                )
+            },
+            city: {
+                options: R.map(
+                    i => ({ label: `label: ${i}`, value: i }),
+                    ['NYC', 'Montreal', 'Miami']
+                )
+            }
+        }}
+    />)
+    .add('editable dropdown shows label', () => <DataTable
+        setProps={setProps}
+        id='table'
+        data={data}
+        columns={columns}
+        editable={true}
+        dropdown={{
+            climate: {
+                options: R.map(
+                    i => ({ label: `label: ${i}`, value: i }),
+                    ['Sunny', 'Snowy', 'Rainy']
+                )
+            },
+            city: {
+                options: R.map(
+                    i => ({ label: `label: ${i}`, value: i }),
+                    ['NYC', 'Montreal', 'Miami']
+                )
+            }
+        }}
+    />)
     .add('dropdown by column', () => (<DataTable
         setProps={setProps}
         id='table'


### PR DESCRIPTION
Closes #524. Fixes regression introduced by https://github.com/plotly/dash-table/pull/281.

- When using a label in-place of dropdown component, make sure to resolve the dropdown label instead of just displaying the value.
- Update tests so that labels are different from values, making testing for this error easier
- Additional visual tests