### PR TITLE
Issue 188 - A simpler interface for multi-line and ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [#567](https://github.com/plotly/dash-table/issues/567)
 - Add support for missing `border-radius` in style_** props
-- Fix table's inner vs. outer container styling 
+- Fix table's inner vs. outer container styling
+
+[#103](https://github.com/plotly/dash-table/issues/103)
+- Simplify usage for multi-line cells and ellipsis. The cell's content now inherits the value of
+`white-space`, `overflow` and `text-overflow` from its parent, making it possible to style
+multi-line & ellipsis with `style_data` and other style props.
 
 ## [4.2.0] - 2019-08-27
 ### Added

--- a/src/core/Stylesheet.ts
+++ b/src/core/Stylesheet.ts
@@ -55,19 +55,6 @@ class StylesheetFacade {
 export default class Stylesheet {
     private stylesheet: StylesheetFacade;
 
-    static unit(dimension: any, defaultUnit: 'em' | 'rem' | 'px' | '%' = 'px') {
-        if (Stylesheet.hasUnit(dimension)) {
-            return dimension;
-        } else {
-            return `${dimension}${defaultUnit}`;
-        }
-    }
-
-    static hasUnit(dimension: any) {
-        return typeof dimension === 'string' &&
-            /^\d+(\.\d+)?(px|em|rem|%)$/.test(dimension);
-    }
-
     constructor(private readonly prefix: string) {
         this.stylesheet = new StylesheetFacade(`${prefix}-dynamic-inline.css`);
     }

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -363,6 +363,12 @@
             height: 30px;
 
             text-align: right;
+
+            div.dash-cell-value {
+                white-space: inherit;
+                overflow: inherit;
+                text-overflow: inherit;
+            }
         }
 
         th {


### PR DESCRIPTION
Fixes #188 

Up to now it was necessary to do:
```
    style_data={'whiteSpace': 'normal'},
    css=[{
        'selector': '.dash-cell div.dash-cell-value',
        'rule': 'display: inline; white-space: inherit; overflow: inherit; text-overflow: inherit;'
    }],
```
in order to allow multiline & ellipsis.

With this change, it is possible to do it with only:
```
    style_data={'whiteSpace': 'normal'},
```

It's also now possible to set `white-space`, `overflow` and `text-overflow` in `style_**` and have it applied (inherited) by the cell's content without extra css.