### PR TITLE
convert R.contains to R.includes

### DIFF
--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -121,7 +121,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
 
         if (selected_cells.length &&
             active_cell &&
-            !R.contains(active_cell, selected_cells)
+            !R.includes(active_cell, selected_cells)
         ) {
             setProps({ active_cell: selected_cells[0] });
         }

--- a/src/dash-table/derived/cell/operations.tsx
+++ b/src/dash-table/derived/cell/operations.tsx
@@ -43,12 +43,12 @@ function rowSelectCell(idx: number, rowSelectable: Selection, selectedRows: numb
             type={rowSelectable === 'single' ? 'radio' : 'checkbox'}
             style={{ verticalAlign: 'middle' }}
             name='row-select'
-            checked={R.contains(idx, selectedRows)}
+            checked={R.includes(idx, selectedRows)}
             onChange={() => {
                 const newSelectedRows = rowSelectable === 'single' ?
                     [idx] :
                     R.ifElse(
-                        R.contains(idx),
+                        R.includes(idx),
                         R.without([idx]),
                         R.append(idx)
                     )(selectedRows);

--- a/src/dash-table/derived/data/virtual.ts
+++ b/src/dash-table/derived/data/virtual.ts
@@ -45,7 +45,7 @@ const getter = (
     const isNully = (
         value: any,
         columnId: ColumnId
-    ) => R.isNil(value) || R.contains(value, getNullyCases(columnId));
+    ) => R.isNil(value) || R.includes(value, getNullyCases(columnId));
 
     if (sort_action === TableAction.Native) {
         data = sort(data, sort_by, isNully);

--- a/src/dash-table/derived/header/content.tsx
+++ b/src/dash-table/derived/header/content.tsx
@@ -48,8 +48,8 @@ const doAction = (
 
     if (action === actions.deleteColumn) {
         if (R.intersection(selected_columns, affectedColumIds).length > 0) {
-            props.selected_columns = R.reject(
-                R.contains(R.__, affectedColumIds),
+            props.selected_columns = R.without(
+                affectedColumIds,
                 selected_columns
             );
         }
@@ -126,10 +126,7 @@ function selectColumn(current_selection: string[], column: IColumn, columns: Col
     } else {
         // 'multi' + unselect -> invert of intersection
         return () => setProps({
-            selected_columns: R.reject(
-                R.contains(R.__, selected_columns),
-                current_selection
-            )
+            selected_columns: R.without(selected_columns, current_selection)
         });
     }
 }

--- a/src/dash-table/syntax-tree/lexicon/index.ts
+++ b/src/dash-table/syntax-tree/lexicon/index.ts
@@ -13,12 +13,12 @@ export const isTerminal = (lexemes: ILexemeResult[], _: ILexemeResult | undefine
 export const isTerminalExpression = (lexemes: ILexemeResult[], previous: ILexemeResult | undefined) =>
     isTerminal(lexemes, previous) &&
     !!previous &&
-    R.contains(previous.lexeme.type, [
+    R.includes(previous.lexeme.type, [
         LexemeType.RelationalOperator
     ]);
 
 export const ifBlockClose = (lexemes: ILexemeResult[], previous: ILexemeResult | undefined) =>
-    !!previous && R.contains(
+    !!previous && R.includes(
         previous.lexeme.type,
         [
             LexemeType.BlockClose,
@@ -29,7 +29,7 @@ export const ifBlockClose = (lexemes: ILexemeResult[], previous: ILexemeResult |
     ) && nestingReducer(0, lexemes) > 0;
 
 export const ifBlockOpen = (_: ILexemeResult[], previous: ILexemeResult | undefined) =>
-    !previous || R.contains(
+    !previous || R.includes(
         previous.lexeme.type,
         [
             LexemeType.BlockOpen,
@@ -39,7 +39,7 @@ export const ifBlockOpen = (_: ILexemeResult[], previous: ILexemeResult | undefi
     );
 
 export const ifExpression = (_: ILexemeResult[], previous: ILexemeResult | undefined) => {
-    return !previous || R.contains(
+    return !previous || R.includes(
         previous.lexeme.type,
         [
             LexemeType.BlockOpen,
@@ -53,7 +53,7 @@ export const ifLeading = (_lexs: ILexemeResult[], previous: ILexemeResult | unde
     !previous;
 
 export const ifLogicalOperator = (_: ILexemeResult[], previous: ILexemeResult | undefined) =>
-    !!previous && R.contains(
+    !!previous && R.includes(
         previous.lexeme.type,
         [
             LexemeType.BlockClose,
@@ -63,7 +63,7 @@ export const ifLogicalOperator = (_: ILexemeResult[], previous: ILexemeResult | 
     );
 
 export const ifRelationalOperator = (_: ILexemeResult[], previous: ILexemeResult | undefined) =>
-    !!previous && R.contains(
+    !!previous && R.includes(
         previous.lexeme.type,
         [LexemeType.Expression]
     );

--- a/src/dash-table/syntax-tree/lexicon/query.ts
+++ b/src/dash-table/syntax-tree/lexicon/query.ts
@@ -50,7 +50,7 @@ import {
 } from '.';
 
 const ifNotUnaryOperator = (_: ILexemeResult[], previous: ILexemeResult | undefined) =>
-    !previous || R.contains(
+    !previous || R.includes(
         previous.lexeme.type,
         [
             LexemeType.LogicalOperator,


### PR DESCRIPTION
@Marc-Andre-Rivet one more quickie to finish purging deprecated `R.contains` from our code. Amusingly `@types/ramda` didn't get the placeholder signatures for `R.includes` (yet? 🙄) but there's a more concise solution anyway...