### PR TITLE
Issue 600 - Incorrect cell validation / coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [#591](https://github.com/plotly/dash-table/issues/591)
 - Fixed row and column selection when multiple tables are present
 
+[#600](https://github.com/plotly/dash-table/issues/600)
+- Fixed reconciliation when validation default value is `0` (number)
+- Apply reconciliation value when deleting cells, if possible
+
 ## [4.3.0] - 2019-09-17
 ### Added
 [#566](https://github.com/plotly/dash-table/pull/566)

--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -36,6 +36,7 @@ import TableTooltip from './fragments/TableTooltip';
 import queryLexicon from 'dash-table/syntax-tree/lexicon/query';
 
 import dataLoading from 'dash-table/derived/table/data_loading';
+import reconcile from 'dash-table/type/reconcile';
 
 const DEFAULT_STYLE = {
     width: '100%'
@@ -410,7 +411,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
         // else we are navigating with arrow keys and extending selection
         // with shift.
 
-        let {minRow, minCol, maxRow, maxCol} = selectionBounds(selected_cells);
+        let { minRow, minCol, maxRow, maxCol } = selectionBounds(selected_cells);
         const selectingDown =
             e.keyCode === KEY_CODES.ARROW_DOWN || e.keyCode === KEY_CODES.ENTER;
         const selectingUp = e.keyCode === KEY_CODES.ARROW_UP;
@@ -459,7 +460,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
         }
 
         const finalSelected = makeSelection(
-            {minRow, maxRow, minCol, maxCol},
+            { minRow, maxRow, minCol, maxCol },
             visibleColumns, viewport
         );
 
@@ -503,10 +504,18 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
         );
 
         realCells.forEach(cell => {
-            if (visibleColumns[cell[1]].editable) {
+            const column = visibleColumns[cell[1]];
+
+            if (column.editable) {
+                /**
+                 * If the cell can reconcile `null`, use this reconciliation value,
+                 * otherwise use the default `''`.
+                 */
+                const result = reconcile(null, column);
+
                 newData = R.set(
-                    R.lensPath([cell[0], visibleColumns[cell[1]].id]),
-                    '',
+                    R.lensPath([cell[0], column.id]),
+                    result.success ? result.value : '',
                     newData
                 );
             }
@@ -522,7 +531,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
 
         const e = event;
 
-        const {row, column} = currentCell;
+        const { row, column } = currentCell;
         let nextCoords;
 
         switch (e.keyCode) {
@@ -787,7 +796,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
             scrollbarWidth
         );
 
-    /* Tooltip */
+        /* Tooltip */
         let tableTooltip = derivedTooltips(
             currentTooltip,
             tooltip_data,
@@ -844,7 +853,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
                             ref={`r${rowIndex}c${columnIndex}`}
                             className={`cell cell-${rowIndex}-${columnIndex} ${c}`}
                         >
-                        {g ? React.cloneElement(g, { style: s.cell }) : g}
+                            {g ? React.cloneElement(g, { style: s.cell }) : g}
                         </div>))}
                     </div>))}
                 </div>

--- a/tests/cypress/tests/unit/numberCoercion_test.ts
+++ b/tests/cypress/tests/unit/numberCoercion_test.ts
@@ -3,7 +3,8 @@ import { isNully } from 'dash-table/type/null';
 import { coerce } from 'dash-table/type/number';
 
 const DEFAULT_COERCE_SUCCESS = [
-    { input: 42, output: 42, name: 'from number' },
+    { input: 0, output: 0, name: 'from number (0)' },
+    { input: 42, output: 42, name: 'from number (42)' },
     { input: '42', output: 42, name: 'from number string' },
     { input: '-42', output: -42, name: 'from negative number string' },
     { input: '4.242', output: 4.242, name: 'from float string' },

--- a/tests/cypress/tests/unit/numberValidation_test.ts
+++ b/tests/cypress/tests/unit/numberValidation_test.ts
@@ -3,7 +3,8 @@ import { isNully } from 'dash-table/type/null';
 import { validate } from 'dash-table/type/number';
 
 const DEFAULT_VALIDATE_SUCCESS = [
-    { input: 42, output: 42, name: 'from number' }
+    { input: 0, output: 0, name: 'from number (0)' },
+    { input: 42, output: 42, name: 'from number (42)' }
 ];
 
 const ALLOW_NULL_VALIDATE_SUCCESS = [

--- a/tests/cypress/tests/unit/reconcile_test.ts
+++ b/tests/cypress/tests/unit/reconcile_test.ts
@@ -1,0 +1,22 @@
+import reconcile from 'dash-table/type/reconcile';
+import { ColumnType, ChangeAction, ChangeFailure } from 'dash-table/components/Table/props';
+
+describe('reconcile', () => {
+    describe('coerce/validate', () => {
+        it('applies default ', () => {
+            const res = reconcile(null, {
+                type: ColumnType.Numeric,
+                on_change: {
+                    action: ChangeAction.Coerce,
+                    failure: ChangeFailure.Default
+                },
+                validation: {
+                    default: 0
+                }
+            });
+
+            expect(res.success).to.equal(true);
+            expect(res.value).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #600 

The `delete cell` operation done through `backspace` on selected cells is already a bit confusing as it will delete content based on whether the column is editable or not. The additional changes to apply defaults is no less confusing but is at least it's aiming to be consistent with how the table would behave if you were to delete content for each cell individually.