### PR TITLE
Issue 545 - Case-insensitive option for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ column filters not working.
 
 ## [4.4.0] - 2019-10-08
 ### Added
+[#545](https://github.com/plotly/dash-table/issues/545)
+- Case insensitive filtering
+- New props: `filter_case` - to control case of all filters, `columns.filter_case_sensitive`, `columns.filter_case_insensitive` - to control filter case for each column
+- New operators: `i=`, `i>=`, `i>`, `i<=`, `i<`, `i!=`, `icontains` - for case-insensitive filtering, `s=`, `s>=`, `s>`, `s<=`, `s<`, `s!=`, `scontains` - to force case-sensitive filtering on case-insensitive columns
+
 [#546](https://github.com/plotly/dash-table/issues/546)
 - New prop `export_columns` that takes values `all` or `visible` (default). This prop controls the columns used during export
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ column filters not working.
 ### Added
 [#545](https://github.com/plotly/dash-table/issues/545)
 - Case insensitive filtering
-- New props: `filter_case` - to control case of all filters, `columns.filter_case_sensitive`, `columns.filter_case_insensitive` - to control filter case for each column
+- New props: `filter_case` - to control case of all filters, `columns.filter_case` - to control filter case for each column
 - New operators: `i=`, `i>=`, `i>`, `i<=`, `i<`, `i!=`, `icontains` - for case-insensitive filtering, `s=`, `s>=`, `s>`, `s<=`, `s<`, `s!=`, `scontains` - to force case-sensitive filtering on case-insensitive columns
 
 [#546](https://github.com/plotly/dash-table/issues/546)

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -78,7 +78,7 @@ class App extends Component<any, any> {
         return (newProps: any) => {
             Logger.debug('--->', newProps);
             this.setState((prevState: any) => ({
-                tableProps: R.merge(prevState.tableProps, newProps)
+                tableProps: R.mergeRight(prevState.tableProps, newProps)
             }));
         };
     });

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -8,6 +8,8 @@ import Logger from 'core/Logger';
 import AppState, { AppMode, AppFlavor } from './AppMode';
 
 import './style.less';
+import FilterCaseButton from 'dash-table/components/Filter/FilterCaseButton';
+import { Case } from 'dash-table/components/Table/props';
 
 class App extends Component<any, any> {
     constructor(props: any) {
@@ -25,7 +27,7 @@ class App extends Component<any, any> {
         const flavors = flavorParam ? flavorParam.split(';') : [];
 
         if (flavors.indexOf(AppFlavor.FilterNative) !== -1) {
-            return (<div>
+            return (<div className='demo-app-root'>
                 <button
                     className='clear-filters'
                     onClick={() => {
@@ -35,6 +37,17 @@ class App extends Component<any, any> {
                         this.setState({ tableProps });
                     }}
                 >Clear Filter</button>
+                <FilterCaseButton
+                    filterCase={this.state.tableProps.filter_case === Case.Insensitive
+                        ? Case.Insensitive : Case.Sensitive}
+                    setColumnCase={() => {
+                        const tableProps = R.clone(this.state.tableProps);
+                        tableProps.filter_case = tableProps.filter_case === Case.Insensitive
+                            ? Case.Sensitive : Case.Insensitive;
+
+                        this.setState({ tableProps });
+                     }}
+                />
                 <input
                     style={{ width: '500px' }}
                     value={this.state.temp_filtering}
@@ -47,6 +60,7 @@ class App extends Component<any, any> {
 
                         this.setState({ tableProps });
                     }} />
+
             </div>);
         } else if (mode === AppMode.TaleOfTwoTables) {
             if (!this.state.tableProps2) {

--- a/demo/AppMode.ts
+++ b/demo/AppMode.ts
@@ -54,7 +54,7 @@ export const BasicModes = [
 function getBaseTableProps(mock: IDataMock): Partial<IProps> {
     return {
         id: 'table',
-        columns: mock.columns.map((col: any) => R.merge(col, {
+        columns: mock.columns.map((col: any) => R.mergeRight(col, {
             name: col.name || col.id,
             on_change: {
                 action: ChangeAction.None
@@ -108,7 +108,7 @@ function getDefaultState(
 
     return {
         filter_query: '',
-        tableProps: R.merge(getBaseTableProps(mock), {
+        tableProps: R.mergeRight(getBaseTableProps(mock), {
             data: mock.data,
             editable: true,
             sort_action: TableAction.Native,
@@ -271,7 +271,7 @@ function getVirtualizedState() {
 
     return {
         filter_query: '',
-        tableProps: R.merge(getBaseTableProps(mock), {
+        tableProps: R.mergeRight(getBaseTableProps(mock), {
             data: mock.data,
             editable: true,
             fill_width: false,

--- a/demo/style.less
+++ b/demo/style.less
@@ -1,3 +1,16 @@
 html {
     font-size: 13px;
+
+    .demo-app-root {
+        input.dash-filter--case {
+            outline: none;
+            height: 18px;
+        }
+
+        input.dash-filter--case--sensitive {
+            border-color: hotpink;
+            border-radius: 4px;
+            border-width: 2px;
+        }
+    }
 }

--- a/src/core/syntax-tree/index.ts
+++ b/src/core/syntax-tree/index.ts
@@ -9,6 +9,7 @@ interface IStructure {
     subType?: string;
     type: string;
     value: any;
+    case: string | undefined;
 
     block?: IStructure;
     left?: IStructure;
@@ -21,7 +22,8 @@ function toStructure(tree: ISyntaxTree): IStructure {
     const res: IStructure = {
         subType: lexeme.subType,
         type: lexeme.type,
-        value: lexeme.present ? lexeme.present(tree) : value
+        value: lexeme.present ? lexeme.present(tree) : value,
+        case: lexeme.case
     };
 
     if (block) {

--- a/src/core/syntax-tree/lexicon.ts
+++ b/src/core/syntax-tree/lexicon.ts
@@ -16,6 +16,7 @@ export interface IUnboundedLexeme {
     resolve?: (target: any, tree: ISyntaxTree) => any;
     subType?: string;
     type: string;
+    case?: string;
     nesting?: number;
     priority?: number;
     regexp: RegExp;

--- a/src/dash-table/components/CellFactory.tsx
+++ b/src/dash-table/components/CellFactory.tsx
@@ -210,7 +210,7 @@ export default class CellFactory {
     ) => {
         return React.cloneElement(wrapper, {
             children: [content],
-            style: R.merge(style, { borderBottom, borderLeft, borderRight, borderTop })
+            style: R.mergeRight(style, { borderBottom, borderLeft, borderRight, borderTop })
         });
     });
 

--- a/src/dash-table/components/Filter/Column.tsx
+++ b/src/dash-table/components/Filter/Column.tsx
@@ -2,6 +2,7 @@ import * as R from 'ramda';
 import React, { CSSProperties, PureComponent } from 'react';
 
 import IsolatedInput from 'core/components/IsolatedInput';
+import FilterCaseButton from './FilterCaseButton';
 
 import { Case, SetProps, IColumn } from 'dash-table/components/Table/props';
 import TableClipboardHelper from 'dash-table/utils/TableClipboardHelper';
@@ -77,9 +78,9 @@ export default class ColumnFilter extends PureComponent<IColumnFilterProps, ISta
             columnFilterCase
         } = this.props;
 
-        const filterCaseClass: string =
-            (globalFilterCase !== Case.Insensitive && columnFilterCase !== Case.Insensitive) ?
-                'dash-filter--case--sensitive' : 'dash-filter--case--insensitive';
+        const filterCase: Case =
+            (globalFilterCase !== Case.Insensitive && columnFilterCase !== Case.Insensitive)
+                ? Case.Sensitive : Case.Insensitive;
 
         return (<th
             className={classes + (isValid ? '' : ' invalid')}
@@ -100,11 +101,9 @@ export default class ColumnFilter extends PureComponent<IColumnFilterProps, ISta
                 submit={this.submit}
             />
             <div>
-                <input
-                    type='button'
-                    className={'dash-filter--case ' + filterCaseClass}
-                    onClick={this.setColumnCase}
-                    value='Aa'
+                <FilterCaseButton
+                    filterCase={filterCase}
+                    setColumnCase={this.setColumnCase}
                 />
             </div>
         </th>);

--- a/src/dash-table/components/Filter/Column.tsx
+++ b/src/dash-table/components/Filter/Column.tsx
@@ -22,19 +22,7 @@ interface IColumnFilterProps {
     columnFilterCase?: Case;
 }
 
-interface IState {
-    value?: string;
-}
-
-export default class ColumnFilter extends PureComponent<IColumnFilterProps, IState> {
-    constructor(props: IColumnFilterProps) {
-        super(props);
-
-        this.state = {
-            value: props.value
-        };
-    }
-
+export default class ColumnFilter extends PureComponent<IColumnFilterProps> {
     private submit = (value: string | undefined) => {
         const { columns, column, setFilter } = this.props;
 

--- a/src/dash-table/components/Filter/FilterCaseButton.tsx
+++ b/src/dash-table/components/Filter/FilterCaseButton.tsx
@@ -1,0 +1,30 @@
+import React, { PureComponent } from 'react';
+
+import { Case } from 'dash-table/components/Table/props';
+
+interface IFilterCaseButtonProps {
+    filterCase: Case;
+    setColumnCase: () => void;
+}
+
+interface IState {
+    value?: string;
+}
+
+export default class FilterCaseButton extends PureComponent<IFilterCaseButtonProps, IState> {
+    constructor(props: IFilterCaseButtonProps) {
+        super(props);
+    }
+
+    render() {
+        const filterCaseClass: string = (this.props.filterCase !== Case.Insensitive) ?
+                'dash-filter--case--sensitive' : 'dash-filter--case--insensitive';
+
+        return (<input
+            type='button'
+            className={'dash-filter--case ' + filterCaseClass}
+            onClick={this.props.setColumnCase}
+            value='Aa'
+        />);
+    }
+}

--- a/src/dash-table/components/Filter/FilterCaseButton.tsx
+++ b/src/dash-table/components/Filter/FilterCaseButton.tsx
@@ -7,15 +7,7 @@ interface IFilterCaseButtonProps {
     setColumnCase: () => void;
 }
 
-interface IState {
-    value?: string;
-}
-
-export default class FilterCaseButton extends PureComponent<IFilterCaseButtonProps, IState> {
-    constructor(props: IFilterCaseButtonProps) {
-        super(props);
-    }
-
+export default class FilterCaseButton extends PureComponent<IFilterCaseButtonProps> {
     render() {
         const filterCaseClass: string = (this.props.filterCase !== Case.Insensitive) ?
                 'dash-filter--case--sensitive' : 'dash-filter--case--insensitive';

--- a/src/dash-table/components/FilterFactory.tsx
+++ b/src/dash-table/components/FilterFactory.tsx
@@ -7,7 +7,7 @@ import memoizerCache from 'core/cache/memoizer';
 import { memoizeOne } from 'core/memoizer';
 
 import ColumnFilter from 'dash-table/components/Filter/Column';
-import { ColumnId, IColumn, TableAction, IFilterFactoryProps, SetFilter } from 'dash-table/components/Table/props';
+import { ColumnId, IColumn, TableAction, IFilterFactoryProps, SetFilter, Case } from 'dash-table/components/Table/props';
 import derivedFilterStyles, { derivedFilterOpStyles } from 'dash-table/derived/filter/wrapperStyles';
 import derivedHeaderOperations from 'dash-table/derived/header/operations';
 import { derivedRelevantFilterStyles } from 'dash-table/derived/style';
@@ -32,19 +32,20 @@ export default class FilterFactory {
 
     }
 
-    private onChange = (column: IColumn, map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, ev: any) => {
+    private onChange = (column: IColumn, map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, filter_case: Case, ev: any) => {
         Logger.debug('Filter -- onChange', column.id, ev.target.value && ev.target.value.trim());
 
         const value = ev.target.value.trim();
 
-        updateColumnFilter(map, column, value, setFilter);
+        updateColumnFilter(map, column, value, setFilter, filter_case);
     }
 
     private filter = memoizerCache<[ColumnId, number]>()((
         column: IColumn,
         index: number,
         map: Map<string, SingleColumnSyntaxTree>,
-        setFilter: SetFilter
+        setFilter: SetFilter,
+        filter_case: Case
     ) => {
         const ast = map.get(column.id.toString());
 
@@ -53,7 +54,7 @@ export default class FilterFactory {
             classes={`dash-filter column-${index}`}
             columnId={column.id}
             isValid={!ast || ast.isValid}
-            setFilter={this.onChange.bind(this, column, map, setFilter)}
+            setFilter={this.onChange.bind(this, column, map, setFilter, filter_case)}
             value={ast && ast.query}
         />);
     });
@@ -83,7 +84,8 @@ export default class FilterFactory {
             style_cell_conditional,
             style_filter,
             style_filter_conditional,
-            visibleColumns
+            visibleColumns,
+            filter_case
         } = this.props;
 
         if (filter_action === TableAction.None) {
@@ -113,7 +115,8 @@ export default class FilterFactory {
                 column,
                 index,
                 map,
-                setFilter
+                setFilter,
+                filter_case
             );
         }, visibleColumns);
 

--- a/src/dash-table/components/FilterFactory.tsx
+++ b/src/dash-table/components/FilterFactory.tsx
@@ -33,12 +33,12 @@ export default class FilterFactory {
     }
 
     private onChange =
-        (map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, column: IColumn, filter_case: Case, ev: any) => {
-        Logger.debug('Filter -- onChange', column.id, ev.target.value && ev.target.value.trim());
+        (map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, column: IColumn, computed_filter_case: Case, ev: any) => {
+        Logger.debug('Filter -- onChange', column.id, ev && ev.trim());
 
-        const value = ev.target.value.trim();
+        const value = ev && ev.trim();
 
-        updateColumnFilter(map, column, value, setFilter, filter_case);
+        updateColumnFilter(map, column, value, setFilter, computed_filter_case);
     }
 
     private filter = memoizerCache<[ColumnId, number]>()((
@@ -61,8 +61,8 @@ export default class FilterFactory {
             setFilter={this.onChange.bind(this, map, setFilter)}
             setProps={setProps}
             value={ast && ast.query}
-            globalFilterCase={filter_case}
-            columnFilterCase={column.filter_case}
+            globalFilterCase={filter_case || Case.Default}
+            columnFilterCase={column.filter_case || Case.Default}
         />);
     });
 

--- a/src/dash-table/components/FilterFactory.tsx
+++ b/src/dash-table/components/FilterFactory.tsx
@@ -32,7 +32,8 @@ export default class FilterFactory {
 
     }
 
-    private onChange = (column: IColumn, map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, filter_case: Case, ev: any) => {
+    private onChange =
+        (map: Map<string, SingleColumnSyntaxTree>, setFilter: SetFilter, column: IColumn, filter_case: Case, ev: any) => {
         Logger.debug('Filter -- onChange', column.id, ev.target.value && ev.target.value.trim());
 
         const value = ev.target.value.trim();
@@ -54,15 +55,14 @@ export default class FilterFactory {
         return (<ColumnFilter
             key={`column-${index}`}
             classes={`dash-filter column-${index}`}
-            columnId={column.id}
+            column={column}
             columns={columns}
             isValid={!ast || ast.isValid}
-            setFilter={this.onChange.bind(this, column, map, setFilter, filter_case)}
+            setFilter={this.onChange.bind(this, map, setFilter)}
             setProps={setProps}
             value={ast && ast.query}
             globalFilterCase={filter_case}
-            columnFilterCaseSensitive={column.filter_case_sensitive}
-            columnFilterCaseInsensitive={column.filter_case_insensitive}
+            columnFilterCase={column.filter_case}
         />);
     });
 

--- a/src/dash-table/components/HeaderFactory.tsx
+++ b/src/dash-table/components/HeaderFactory.tsx
@@ -56,7 +56,8 @@ export default class HeaderFactory {
             style_cell_conditional,
             style_header,
             style_header_conditional,
-            visibleColumns
+            visibleColumns,
+            filter_case
         } = props;
 
         const labelsAndIndices = this.labelsAndIndices(columns, visibleColumns, merge_duplicate_headers);
@@ -109,7 +110,8 @@ export default class HeaderFactory {
             page_action,
             setFilter,
             setProps,
-            merge_duplicate_headers
+            merge_duplicate_headers,
+            filter_case
         );
 
         const ops = this.getHeaderOpCells(

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -143,82 +143,80 @@
 .dash-table-container {
 
     .previous-next-container {
-	display: inline-block;
-	float: right;
-	padding: 5px 0px;
+        float: right;
+        padding: 5px 0px;
 
+        .page-number {
+            font-family: monospace;
+            display: inline-block;
+            .last-page {
+            min-width: 30px;
+            display: inline-block;
+            text-align: center;
+            margin: 0.5em;
+            }
+        }
 
-	.page-number {
-	    font-family: monospace;
-	    display: inline-block;
-	    .last-page {
-		min-width: 30px;
-		display: inline-block;
-		text-align: center;
-		margin: 0.5em;
-	    }
-	}
+        input.current-page {
+            display: inline-block;
+            border-bottom: solid lightgrey 1px !important;
+            color: black;
+            border: none;
+            width: 30px;
+            text-align: center;
+            font-family: monospace;
+            font-size: 10pt;
+            margin: 0.5em;
 
-	input.current-page {
-	    display: inline-block;
-	    border-bottom: solid lightgrey 1px !important;
-	    color: black;
-	    border: none;
-	    width: 30px;
-	    text-align: center;
-	    font-family: monospace;
-	    font-size: 10pt;
-	    margin: 0.5em;
+            &::placeholder {
+                color: black;
+            }
+            
+            &:focus {
+                outline: none;
+                
+                &::placeholder {
+                    opacity: 0;
+                }
+            }
+        }
 
-	    &::placeholder {
-		color: black;
-	    }
-	    
-	    &:focus {
-		outline: none;
-		
-		&::placeholder {
-		    opacity: 0;
-		}
-	    }
-	}
+        button.previous-page, button.next-page, button.first-page, button.last-page {
+            transition-duration: 400ms;
+            padding: 5px;
+            border: none;
+            display: inline-block;
+            margin-left: 5px;
+            margin-right: 5px;
 
-	button.previous-page, button.next-page, button.first-page, button.last-page {
-	    transition-duration: 400ms;
-	    padding: 5px;
-	    border: none;
-	    display: inline-block;
-	    margin-left: 5px;
-	    margin-right: 5px;
+            &:hover {
+                color: hotpink;
+                
+                &:disabled {
+                    color: graytext
+                }
+            }
 
-	    &:hover {
-		color: hotpink;
-		
-		&:disabled {
-		    color: graytext
-		}
-	    }
-
-	    &:focus {
-		outline: none;
-	    }
-	}
+            &:focus {
+            outline: none;
+            }
+        }
     }
     
     .dash-spreadsheet-container {
-	.reset-css();
-	display: flex;
-	flex-direction: row;
-	position: relative;
+        .reset-css();
+        display: flex;
+        flex-direction: row;
+        position: relative;
 
-	// This overrides Chrome's default `font-size: medium;` which is causing performance issues
-	// with AutoInputResize sub-component in react-select
-	// https://github.com/JedWatson/react-input-autosize/blob/05b0f86a7f8b16de99c2b31296ff0d3307f15957/src/AutosizeInput.js#L58
-	table {
+        // This overrides Chrome's default `font-size: medium;` which is causing performance issues
+        // with AutoInputResize sub-component in react-select
+        // https://github.com/JedWatson/react-input-autosize/blob/05b0f86a7f8b16de99c2b31296ff0d3307f15957/src/AutosizeInput.js#L58
+        table {
             font-size: inherit;
-	}
+        }
 
-	.dash-spreadsheet-inner {
+        .dash-spreadsheet-inner {
             box-sizing: border-box;
             display: flex;
             flex-direction: column;
@@ -226,230 +224,245 @@
             *,
             *:after,
             *:before {
-		box-sizing: inherit;
+		        box-sizing: inherit;
             }
 
             .Select {
-		overflow: hidden;
-		position: static;
+                overflow: hidden;
+                position: static;
             }
 
             .Select,
             .Select-control {
-		background-color: inherit;
+		        background-color: inherit;
             }
 
             .Select-value {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		margin-top: -2px;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                margin-top: -2px;
             }
 
             .marker-row {
-		tr {
+                tr {
                     visibility: hidden !important;
-		}
+                }
 
-		td, th {
+		        td, th {
                     height: 0 !important;
                     padding: 0 !important;
                     margin: 0 !important;
-		}
+		        }
             }
 
             .dash-filter {
-		input::placeholder {
+		        input::placeholder {
                     color: inherit;
                     font-size: 0.8em;
                     padding-right: 5px;
-		}
+                }
 
-		& + .dash-filter {
+                & + .dash-filter {
                     &:not(:hover):not(:focus-within) {
-			input::placeholder {
+			            input::placeholder {
                             color: transparent;
-			}
+			            }
                     }
-		}
+		        }
 
-		&.invalid {
+		        &.invalid {
                     background-color: pink;
-		}
+		        }
             }
 
             &:not(.dash-empty-11) {
-		.row-0 {
+		        .row-0 {
                     tr:last-of-type {
-			td, th {
+			            td, th {
                             border-bottom: none !important;
-			}
+			            }
                     }
-		}
+		        }
             }
 
             &:not(.dash-empty-01) {
-		.cell-0-0,
-		.cell-1-0 {
+                .cell-0-0,
+                .cell-1-0 {
                     tr {
-			td:last-of-type,
-			th:last-of-type {
+                        td:last-of-type,
+                        th:last-of-type {
                             border-right: none !important;
-			}
+			            }
                     }
-		}
+		        }
             }
 
             &.dash-freeze-left,
             &.dash-freeze-top,
             &.dash-virtualized {
-		overflow: hidden !important;
+                overflow: hidden !important;
 
-		.row-0 {
+                .row-0 {
                     display: flex;
                     flex: 0 0 auto;
                     flex-direction: row;
-		}
+                }
 
-		.row-1 {
+                .row-1 {
                     display: flex;
                     flex-direction: row;
                     overflow: auto;
-		}
+                }
 
-		.cell-0-0,
-		.cell-1-0 {
+                .cell-0-0,
+                .cell-1-0 {
                     flex: 0 0 auto;
                     left: 0;
                     position: sticky;
                     position:-webkit-sticky;
                     z-index: 400;
-		}
+                }
 
-		.cell-0-1 {
+                .cell-0-1 {
                     z-index: 300;
                     flex: 0 0 auto;
-		}
+                }
 
-		.cell-1-1 {
+                .cell-1-1 {
                     flex: 0 0 auto;
-		}
+                }
             }
 
             &.dash-fill-width {
-		.cell-0-1,
-		.cell-1-1 {
+                .cell-0-1,
+                .cell-1-1 {
                     flex: 1 0 auto;
-		}
+		        }
 
-		table {
+		        table {
                     width: 100%;
-		}
+		        }
             }
 
             td {
-		background-color: inherit;
+                background-color: inherit;
 
-		&.focused {
+                &.focused {
                     margin: -1px;
                     z-index: 200;
-		}
+                }
 
-		.dash-cell-value-container {
+                .dash-cell-value-container {
                     width: 100%;
                     height: 100%;
-		}
+                }
 
-		.dash-input-cell-value-container {
+                .dash-input-cell-value-container {
                     position: relative;
-		}
+                }
 
-		.dash-cell-value {
+                .dash-cell-value {
                     height: 100%;
                     width: 100%;
-		}
+                }
 
-		input.dash-cell-value {
+                input.dash-cell-value {
                     position: absolute;
                     left: 0;
                     top: 0;
                     &.unfocused::selection {
-			background-color: transparent;
+			            background-color: transparent;
                     }
                     &.unfocused {
-			caret-color: transparent;
+			            caret-color: transparent;
                     }
-		}
+		        }
 
-		.cell-value-shadow {
+		        .cell-value-shadow {
                     margin: auto 0;
                     opacity: 0;
-		}
+                }
 
-		.input-cell-value-shadow {
+                .input-cell-value-shadow {
                     display: inline-block;
                     height: initial;
                     width: initial;
-		}
+                }
 
-		.dropdown-cell-value-shadow {
+                .dropdown-cell-value-shadow {
                     display: block;
                     height: 0px;
                     padding: 0 42px 0 10px;
-		}
+		        }
             }
 
             th.dash-filter {
-		position: relative;
+                position: relative;
 
-		& input {
+                & input {
                     position: absolute;
                     left: 0;
                     top: 0;
                     height: 100%;
                     width: 100%;
-		}
+                    &.dash-filter--case {
+                        position: relative;
+                        left: auto;
+                        top: auto;
+                        width: auto;
+                        height: 16px;
+                        line-height: 0px;
+                        padding: 1px;
+                    }
+                    &.dash-filter--case--sensitive {
+                        border-width: 1px;
+                        border-style: solid;
+                        border-radius: 3px;
+                    }
+		        }
             }
 
             th {
-		white-space: nowrap;
+                white-space: nowrap;
 
-		.column-header--clear,
-		.column-header--delete,
-		.column-header--edit,
-		.column-header--hide
-		    .column-header--sort {
+                .dash-filter--case,
+                .column-header--clear,
+                .column-header--delete,
+                .column-header--edit,
+                .column-header--hide
+                .column-header--sort {
                     .not-selectable();
                     cursor: pointer;
-		}
+                }
             }
 
             // cell content styling
             td, th {
-		background-clip: padding-box;
-		padding: 2px;
-		overflow-x: hidden;
-		white-space: nowrap;
+                background-clip: padding-box;
+                padding: 2px;
+                overflow-x: hidden;
+                white-space: nowrap;
 
-		height: 30px;
+                height: 30px;
 
-		text-align: right;
+                text-align: right;
 
-		div.dash-cell-value {
+                div.dash-cell-value {
                     display: inline;
                     vertical-align: middle;
                     white-space: inherit;
                     overflow: inherit;
                     text-overflow: inherit;
-		}
+		        }
             }
-	}
+        }
 
-	.dash-spreadsheet-inner textarea {
+        .dash-spreadsheet-inner textarea {
             white-space: pre;
-	}
+        }
 
-	.dash-spreadsheet-inner table {
+        .dash-spreadsheet-inner table {
             border-collapse: collapse;
 
             font-family: monospace;
@@ -463,24 +476,24 @@
             --selected-background: rgba(255, 65, 54, 0.2);
             --faded-dropdown: rgb(240, 240, 240);
             --muted: rgb(200, 200, 200);
-	}
+        }
 
-	/* focus happens after copying to clipboard */
-	.dash-spreadsheet-inner table:focus {
+        /* focus happens after copying to clipboard */
+        .dash-spreadsheet-inner table:focus {
             outline: none;
-	}
+        }
 
-	.dash-spreadsheet-inner thead {
+        .dash-spreadsheet-inner thead {
             display: table-row-group;
-	}
+        }
 
-	.elip {
+        .elip {
             text-align: center;
             width: 100%;
             background-color: var(--background-color-ellipses);
-	}
+        }
 
-	.dash-spreadsheet-inner td.dropdown {
+        .dash-spreadsheet-inner td.dropdown {
             /*
              * To view the dropdown's contents, we need
              * overflow-y: visible.
@@ -494,30 +507,30 @@
              * tried it.
              */
             overflow-x: visible;
-	}
+        }
 
-	.dash-spreadsheet-inner :not(.cell--selected) tr:hover,
-	tr:hover input :not(.cell--selected) {
+        .dash-spreadsheet-inner :not(.cell--selected) tr:hover,
+        tr:hover input :not(.cell--selected) {
             background-color: var(--hover);
-	}
+        }
 
-	.dash-spreadsheet-inner th {
+        .dash-spreadsheet-inner th {
             background-color: rgb(250, 250, 250);
-	}
+        }
 
-	.dash-spreadsheet-inner td {
+        .dash-spreadsheet-inner td {
             background-color: white;
-	}
+        }
 
-	.expanded-row--empty-cell {
+        .expanded-row--empty-cell {
             background-color: transparent;
-	}
+        }
 
-	.expanded-row {
+        .expanded-row {
             text-align: center;
-	}
+        }
 
-	.dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
+        .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
             padding: 0px;
             margin: 0px;
             height: calc(100% - 1px);
@@ -534,19 +547,19 @@
              * or bare `td`
              */
             text-shadow: none;
-	}
+        }
 
-	.dash-spreadsheet-inner input.unfocused {
+        .dash-spreadsheet-inner input.unfocused {
             color: transparent;
             text-shadow: 0 0 0 var(--text-color);
             cursor: default;
-	}
+        }
 
-	.dash-spreadsheet-inner input.unfocused:focus {
+        .dash-spreadsheet-inner input.unfocused:focus {
             outline: none;
-	}
+        }
 
-	.toggle-row {
+        .toggle-row {
             border: none;
             box-shadow: none;
             width: 10px;
@@ -554,61 +567,76 @@
             padding-right: 10px;
             cursor: pointer;
             color: var(--faded-text);
-	}
+        }
 
-	.toggle-row--expanded {
+        .toggle-row--expanded {
             color: var(--accent);
-	}
+        }
 
-	.dash-spreadsheet-inner tr:hover .toggle-row {
+        .dash-spreadsheet-inner tr:hover .toggle-row {
             color: var(--accent);
-	}
+        }
 
-	.dash-spreadsheet-inner .dash-delete-cell,
-	.dash-spreadsheet-inner .dash-delete-header {
+        .dash-spreadsheet-inner .dash-delete-cell,
+        .dash-spreadsheet-inner .dash-delete-header {
             .not-selectable();
 
             font-size: 1.3rem;
             text-align: center;
             cursor: pointer;
             color: var(--muted);
-	}
-	.dash-spreadsheet-inner .dash-delete-cell:hover,
-	.dash-spreadsheet-inner .dash-delete-header:hover {
+        }
+        .dash-spreadsheet-inner .dash-delete-cell:hover,
+        .dash-spreadsheet-inner .dash-delete-header:hover {
             color: var(--accent);
-	}
+        }
 
-	.dash-spreadsheet-inner {
-            [class^='column-header--'] {
-		cursor: pointer;
-		float: left;
+        .dash-spreadsheet-inner {
+            [class^='column-header--'],[class^='dash-filter--'] {
+                cursor: pointer;
+                float: left;
+            }
+            
+            .dash-filter--case {
+                font-weight: 900;
             }
 
+            .dash-filter--case,
             .column-header--select {
-		height: auto;
+		        height: auto;
             }
 
             .column-header--select,
             .column-header--sort {
-		color: var(--faded-text-header);
+		        color: var(--faded-text-header);
             }
 
-
+            .dash-filter--case,
             .column-header--clear,
             .column-header--delete,
             .column-header--edit,
             .column-header--hide {
-		opacity: 0.1;
-		padding-left: 2px;
-		padding-right: 2px;
+                opacity: 0.1;
+                padding-left: 2px;
+                padding-right: 2px;
             }
 
             th:hover {
-		[class^='column-header--']:not(.disabled) {
+		        [class^='column-header--'],[class^='dash-filter--']:not(.disabled) {
                     color: var(--accent);
                     opacity: 1;
-		}
+		        }
             }
-	}
+
+            .dash-filter--case {
+                font-size: 10px;
+            }
+
+            .dash-filter--case--sensitive {
+                border-width: 1px;
+                border-style: solid;
+                border-radius: 3px;
+            }
+	    }
     }
 }

--- a/src/dash-table/components/Table/controlledPropsHelper.ts
+++ b/src/dash-table/components/Table/controlledPropsHelper.ts
@@ -47,7 +47,7 @@ export default () => {
             uiViewport,
             virtualization,
             visibleColumns
-        } = R.merge(props, state) as (SanitizedAndDerivedProps & StandaloneState);
+        } = R.mergeRight(props, state) as (SanitizedAndDerivedProps & StandaloneState);
 
         const virtual = getVirtual(
             visibleColumns,

--- a/src/dash-table/components/Table/index.tsx
+++ b/src/dash-table/components/Table/index.tsx
@@ -40,7 +40,8 @@ export default class Table extends Component<SanitizedAndDerivedProps, Standalon
                 map: this.filterMap(
                     new Map<string, SingleColumnSyntaxTree>(),
                     props.filter_query,
-                    props.visibleColumns
+                    props.visibleColumns,
+                    props.filter_case
                 )
             },
             rawFilterQuery: '',
@@ -60,7 +61,8 @@ export default class Table extends Component<SanitizedAndDerivedProps, Standalon
                 const map = this.filterMap(
                     currentMap,
                     nextProps.filter_query,
-                    nextProps.visibleColumns
+                    nextProps.visibleColumns,
+                    nextProps.filter_case
                 );
 
                 return map !== currentMap ? { workFilter: { map, value} } : null;

--- a/src/dash-table/components/Table/props.ts
+++ b/src/dash-table/components/Table/props.ts
@@ -46,6 +46,12 @@ export enum SortMode {
     Multi = 'multi'
 }
 
+export enum Case {
+    Sensitive = 'sensitive',
+    Insensitive = 'insensitive',
+    Default = 'default'
+}
+
 export enum TableAction {
     Custom = 'custom',
     Native = 'native',
@@ -177,6 +183,8 @@ export interface IBaseColumn {
     hideable?: boolean | boolean[] | 'first' | 'last';
     renamable?: boolean | boolean[] | 'first' | 'last';
     selectable?: boolean | boolean[] | 'first' | 'last';
+    filter_case_sensitive?: boolean;
+    filter_case_insensitive?: boolean;
     sort_as_null: SortAsNull;
     id: ColumnId;
     name: string | string[];
@@ -298,6 +306,7 @@ export interface IProps {
     fill_width?: boolean;
     filter_query?: string;
     filter_action?: TableAction;
+    filter_case?: Case;
     hidden_columns?: string[];
     include_headers_on_copy_paste?: boolean;
     locale_format: INumberLocale;
@@ -352,6 +361,7 @@ interface IDefaultProps {
     fill_width: boolean;
     filter_query: string;
     filter_action: TableAction;
+    filter_case: Case;
     include_headers_on_copy_paste: boolean;
     merge_duplicate_headers: boolean;
     fixed_columns: Fixed;
@@ -442,6 +452,7 @@ export type SetFilter = (
 export interface IFilterFactoryProps {
     filter_query: string;
     filter_action: TableAction;
+    filter_case: Case;
     id: string;
     map: Map<string, SingleColumnSyntaxTree>;
     rawFilterQuery: string;

--- a/src/dash-table/components/Table/props.ts
+++ b/src/dash-table/components/Table/props.ts
@@ -49,7 +49,7 @@ export enum SortMode {
 export enum Case {
     Sensitive = 'sensitive',
     Insensitive = 'insensitive',
-    Default = 'default'
+    Default = ''
 }
 
 export enum TableAction {
@@ -90,7 +90,7 @@ export interface ICellCoordinates {
 export type ColumnId = string;
 export type Columns = IColumn[];
 export type Data = Datum[];
-export type Datum =  IDatumObject | any;
+export type Datum = IDatumObject | any;
 export type Indices = number[];
 export type RowId = string | number;
 export type SelectedCells = ICellCoordinates[];
@@ -178,13 +178,12 @@ export interface IDatetimeColumn extends ITypeColumn {
 
 export interface IBaseColumn {
     clearable?: boolean | boolean[] | 'first' | 'last';
-    deletable?: boolean | boolean[] | 'first' |'last';
+    deletable?: boolean | boolean[] | 'first' | 'last';
     editable: boolean;
     hideable?: boolean | boolean[] | 'first' | 'last';
     renamable?: boolean | boolean[] | 'first' | 'last';
     selectable?: boolean | boolean[] | 'first' | 'last';
-    filter_case_sensitive?: boolean;
-    filter_case_insensitive?: boolean;
+    filter_case?: Case;
     sort_as_null: SortAsNull;
     id: ColumnId;
     name: string | string[];

--- a/src/dash-table/components/Table/props.ts
+++ b/src/dash-table/components/Table/props.ts
@@ -450,6 +450,7 @@ export type SetFilter = (
 ) => void;
 
 export interface IFilterFactoryProps {
+    columns: IColumn[];
     filter_query: string;
     filter_action: TableAction;
     filter_case: Case;
@@ -459,6 +460,7 @@ export interface IFilterFactoryProps {
     row_deletable: boolean;
     row_selectable: Selection;
     setFilter: SetFilter;
+    setProps: SetProps;
     style_cell: Style;
     style_cell_conditional: Cells;
     style_filter: Style;

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -47,6 +47,7 @@ export const defaultProps = {
     css: [],
     filter_query: '',
     filter_action: 'none',
+    filter_case: 'sensitive',
     sort_as_null: [],
     sort_action: 'none',
     sort_mode: 'single',
@@ -249,13 +250,24 @@ export const propTypes = {
          * will select *all* of the merged columns associated with it.
          * The table-level prop `column_selectable` is used to determine the type of column
          * selection to use.
-         *
          */
         selectable: PropTypes.oneOfType([
             PropTypes.oneOf(['first', 'last']),
             PropTypes.bool,
             PropTypes.arrayOf(PropTypes.bool)
         ]),
+
+        /**
+         * If true, the filter on the column will override the table setting and always be
+         * case-sensitive, unless a case-insensitive operator is used.
+         */
+        filter_case_sensitive: PropTypes.bool,
+
+        /**
+         * If true, the filter on the column will override the table setting and will always be
+         * case-insensitive, nless a case-sensitive operator is used.
+         */
+        filter_case_insensitive: PropTypes.bool,
 
         /**
          * The formatting applied to the column's data.
@@ -956,13 +968,6 @@ export const propTypes = {
     tooltip_duration: PropTypes.number,
 
     /**
-     * If `filter_action` is enabled, then the current filtering
-     * string is represented in this `filter_query`
-     * property.
-     */
-    filter_query: PropTypes.string,
-
-    /**
      * The `filter_action` property controls the behavior of the `filtering` UI.
      * If `'none'`, then the filtering UI is not displayed.
      * If `'native'`, then the filtering UI is displayed and the filtering
@@ -974,6 +979,22 @@ export const propTypes = {
      * and `data` would be the output).
      */
     filter_action: PropTypes.oneOf(['custom', 'native', 'none']),
+
+    /**
+     * If `filter_action` is enabled, then the current filtering
+     * string is represented in this `filter_query`
+     * property.
+     */
+    filter_query: PropTypes.string,
+
+    /**
+     * If `filter_action` is enabled, the `filter_case` property controls the case-sensitivity of
+     * the filters.
+     * If `'sensitive'`, filtering on all columns will be case-sensitive (default behavior).
+     * If `'insensitive'`, filtering on all columns will be case-insensitive.
+     * This setting can be overridden per column.
+     */
+    filter_case: PropTypes.oneOf(['sensitive', 'insensitive']),
 
     /**
      * The `sort_action` property enables data to be
@@ -1142,7 +1163,7 @@ export const propTypes = {
      * subType (string; optional):
      *   'open-block': '()',
      *   'logical-operator': '&&', '||',
-     *   'relational-operator': '=', '>=', '>', '<=', '<', '!=', 'contains',
+     *   'relational-operator': '=', '>=', '>', '<=', '<', '!=', 'contains', 'i=', 'i>=', 'i>', 'i<=', 'i<', 'i!=', 'icontains', 's=', 's>=', 's>', 's<=', 's<', 's!=', 'scontains',
      *   'unary-operator': '!', 'is bool', 'is even', 'is nil', 'is num', 'is object', 'is odd', 'is prime', 'is str',
      *   'expression': 'value', 'field';
      * value (any):

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -258,16 +258,10 @@ export const propTypes = {
         ]),
 
         /**
-         * If true, the filter on the column will override the table setting and always be
-         * case-sensitive, unless a case-insensitive operator is used.
+         * If not blank, the filter on the column will override the table setting and always be
+         * case-sensitive, or case-insensitive unless a case-specific operator is used.
          */
-        filter_case_sensitive: PropTypes.bool,
-
-        /**
-         * If true, the filter on the column will override the table setting and will always be
-         * case-insensitive, nless a case-sensitive operator is used.
-         */
-        filter_case_insensitive: PropTypes.bool,
+        filter_case: PropTypes.oneOf(['', 'sensitive', 'insensitive']),
 
         /**
          * The formatting applied to the column's data.

--- a/src/dash-table/dash/Sanitizer.ts
+++ b/src/dash-table/dash/Sanitizer.ts
@@ -87,7 +87,7 @@ export default class Sanitizer {
             headerFormat = ExportHeaders.Ids;
         }
 
-        return R.merge(props, {
+        return R.mergeRight(props, {
             columns,
             export_headers: headerFormat,
             fixed_columns: getFixedColumns(props.fixed_columns, props.row_deletable, props.row_selectable),

--- a/src/dash-table/derived/cell/wrapperStyles.ts
+++ b/src/dash-table/derived/cell/wrapperStyles.ts
@@ -34,7 +34,7 @@ const getter = (
             return;
         }
 
-        styles[i][j] = R.merge(styles[i][j], SELECTED_CELL_STYLE);
+        styles[i][j] = R.mergeRight(styles[i][j], SELECTED_CELL_STYLE);
     }, selectedCells);
 
     return styles;

--- a/src/dash-table/derived/filter/map.ts
+++ b/src/dash-table/derived/filter/map.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 
 import { memoizeOneFactory } from 'core/memoizer';
 
-import { Columns, IColumn, SetFilter } from 'dash-table/components/Table/props';
+import { Columns, IColumn, SetFilter, Case } from 'dash-table/components/Table/props';
 import { SingleColumnSyntaxTree, MultiColumnsSyntaxTree, getMultiColumnQueryString, getSingleColumnMap } from 'dash-table/syntax-tree';
 
 const cloneIf = (
@@ -13,10 +13,11 @@ const cloneIf = (
 export default memoizeOneFactory((
     map: Map<string, SingleColumnSyntaxTree>,
     query: string,
-    columns: Columns
+    columns: Columns,
+    filter_case: Case
 ): Map<string, SingleColumnSyntaxTree> => {
     const multiQuery = new MultiColumnsSyntaxTree(query);
-    const reversedMap = getSingleColumnMap(multiQuery, columns);
+    const reversedMap = getSingleColumnMap(multiQuery, columns, filter_case);
 
     /*
      * Couldn't process the query, just use the previous value.
@@ -61,12 +62,12 @@ export default memoizeOneFactory((
     return newMap;
 });
 
-function updateMap(map: Map<string, SingleColumnSyntaxTree>, column: IColumn, value: any) {
+function updateMap(map: Map<string, SingleColumnSyntaxTree>, column: IColumn, value: any, filter_case: Case) {
     const id = column.id.toString();
     const newMap = new Map<string, SingleColumnSyntaxTree>(map);
 
     if (value && value.length) {
-        newMap.set(id, new SingleColumnSyntaxTree(value, column));
+        newMap.set(id, new SingleColumnSyntaxTree(value, column, filter_case));
     } else {
         newMap.delete(id);
     }
@@ -90,19 +91,21 @@ export const updateColumnFilter = (
     map: Map<string, SingleColumnSyntaxTree>,
     column: IColumn,
     value: any,
-    setFilter: SetFilter
+    setFilter: SetFilter,
+    filter_case: Case
 ) => {
-    map = updateMap(map, column, value);
+    map = updateMap(map, column, value, filter_case);
     updateState(map, setFilter);
 };
 
 export const clearColumnsFilter = (
     map: Map<string, SingleColumnSyntaxTree>,
     columns: Columns,
-    setFilter: SetFilter
+    setFilter: SetFilter,
+    filter_case: Case
 ) => {
     R.forEach(column => {
-        map = updateMap(map, column, '');
+        map = updateMap(map, column, '', filter_case);
     }, columns);
 
     updateState(map, setFilter);

--- a/src/dash-table/derived/header/content.tsx
+++ b/src/dash-table/derived/header/content.tsx
@@ -15,7 +15,8 @@ import {
     SetFilter,
     SetProps,
     SortMode,
-    TableAction
+    TableAction,
+    Case
 } from 'dash-table/components/Table/props';
 import getColumnFlag from 'dash-table/derived/header/columnFlag';
 import * as actions from 'dash-table/utils/actions';
@@ -40,7 +41,8 @@ const doAction = (
     setFilter: SetFilter,
     setProps: SetProps,
     map: Map<string, SingleColumnSyntaxTree>,
-    data: Data
+    data: Data,
+    filter_case: Case
 ) => () => {
     const props = action(column, columns, visibleColumns, columnRowIndex, mergeDuplicateHeaders, data);
 
@@ -64,7 +66,7 @@ const doAction = (
         }
     }, affectedColumIds);
 
-    clearColumnsFilter(map, affectedColumns, setFilter);
+    clearColumnsFilter(map, affectedColumns, setFilter, filter_case);
 };
 
 function doSort(columnId: ColumnId, sortBy: SortBy, mode: SortMode, setProps: SetProps) {
@@ -165,7 +167,8 @@ function getter(
     paginationMode: TableAction,
     setFilter: SetFilter,
     setProps: SetProps,
-    mergeDuplicateHeaders: boolean
+    mergeDuplicateHeaders: boolean,
+    filter_case: Case
 ): JSX.Element[][] {
     return R.addIndex<R.KeyValuePair<any[], number[]>, JSX.Element[]>(R.map)(
         ([labels, indices], headerRowIndex) => {
@@ -263,7 +266,7 @@ function getter(
                             null :
                             (<span
                                 className='column-header--clear'
-                                onClick={doAction(actions.clearColumn, selected_columns, column, columns, visibleColumns, headerRowIndex, mergeDuplicateHeaders, setFilter, setProps, map, data)}
+                                onClick={doAction(actions.clearColumn, selected_columns, column, columns, visibleColumns, headerRowIndex, mergeDuplicateHeaders, setFilter, setProps, map, data, filter_case)}
                             >
                                 <FontAwesomeIcon icon='eraser' />
                             </span>)
@@ -275,7 +278,7 @@ function getter(
                                 className={'column-header--delete' + (spansAllColumns ? ' disabled' : '')}
                                 onClick={spansAllColumns ?
                                     undefined :
-                                    doAction(actions.deleteColumn, selected_columns, column, columns, visibleColumns, headerRowIndex, mergeDuplicateHeaders, setFilter, setProps, map, data)
+                                    doAction(actions.deleteColumn, selected_columns, column, columns, visibleColumns, headerRowIndex, mergeDuplicateHeaders, setFilter, setProps, map, data, filter_case)
                                 }
                             >
                                 <FontAwesomeIcon icon={['far', 'trash-alt']} />

--- a/src/dash-table/derived/table/index.tsx
+++ b/src/dash-table/derived/table/index.tsx
@@ -25,7 +25,7 @@ const handleSetFilter = (
 function propsAndMapFn(propsFn: () => ControlledTableProps, setFilter: any) {
     const props = propsFn();
 
-    return R.merge(props, { map: props.workFilter.map, setFilter });
+    return R.mergeRight(props, { map: props.workFilter.map, setFilter });
 }
 
 export default (propsFn: () => ControlledTableProps) => {

--- a/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
+++ b/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
@@ -74,7 +74,7 @@ function modifyLex(config: SingleColumnConfig, filter_case: Case, res: ILexerRes
         ];
     }
 
-    if ((filter_case === 'insensitive' || config.filter_case_insensitive)
+    if ((filter_case === 'insensitive' || config.filter_case === 'insensitive')
         && isRelational(res.lexemes) && isDefaultCase(res.lexemes)) {
         const replacement: ILexemeResult =
             CaseMapping.get(res.lexemes[1].lexeme.subType as RelationalOperator) as ILexemeResult;
@@ -89,8 +89,7 @@ function modifyLex(config: SingleColumnConfig, filter_case: Case, res: ILexerRes
 
 export type SingleColumnConfig = RequiredPluck<IColumn, 'id'> &
     OptionalPluck<IColumn, 'type'> &
-    OptionalPluck<IColumn, 'filter_case_sensitive'> &
-    OptionalPluck<IColumn, 'filter_case_insensitive'>;
+    OptionalPluck<IColumn, 'filter_case'>;
 
 export default class SingleColumnSyntaxTree extends SyntaxTree {
     constructor(query: string, config: SingleColumnConfig, filter_case: Case) {

--- a/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
+++ b/src/dash-table/syntax-tree/SingleColumnSyntaxTree.ts
@@ -56,7 +56,7 @@ function isDefaultCase(lexemes: ILexemeResult[]) {
     return lexemes[1].lexeme.case === 'default';
 }
 
-function modifyLex(config: SingleColumnConfig, filter_case: Case, res: ILexerResult) {
+function modifyLex(config: SingleColumnConfig, computed_filter_case: Case, res: ILexerResult) {
     if (!res.valid) {
         return res;
     }
@@ -74,13 +74,12 @@ function modifyLex(config: SingleColumnConfig, filter_case: Case, res: ILexerRes
         ];
     }
 
-    if ((filter_case === 'insensitive' || config.filter_case === 'insensitive')
-        && isRelational(res.lexemes) && isDefaultCase(res.lexemes)) {
+    if ((computed_filter_case === 'insensitive') && isRelational(res.lexemes) && isDefaultCase(res.lexemes)) {
         const replacement: ILexemeResult =
             CaseMapping.get(res.lexemes[1].lexeme.subType as RelationalOperator) as ILexemeResult;
         res.lexemes[1] = {
-            lexeme: R.mergeRight(res.lexemes[1].lexeme,
-                replacement.lexeme), value: replacement.value
+            lexeme: R.mergeRight(res.lexemes[1].lexeme, replacement.lexeme),
+            value: replacement.value
         };
     }
 
@@ -92,11 +91,11 @@ export type SingleColumnConfig = RequiredPluck<IColumn, 'id'> &
     OptionalPluck<IColumn, 'filter_case'>;
 
 export default class SingleColumnSyntaxTree extends SyntaxTree {
-    constructor(query: string, config: SingleColumnConfig, filter_case: Case) {
+    constructor(query: string, config: SingleColumnConfig, computed_filter_case: Case) {
         super(
             columnLexicon,
             query,
-            modifyLex.bind(undefined, config, filter_case)
+            modifyLex.bind(undefined, config, computed_filter_case)
         );
     }
 }

--- a/src/dash-table/syntax-tree/index.ts
+++ b/src/dash-table/syntax-tree/index.ts
@@ -6,7 +6,7 @@ import MultiColumnsSyntaxTree from './MultiColumnsSyntaxTree';
 import QuerySyntaxTree from './QuerySyntaxTree';
 import SingleColumnSyntaxTree from './SingleColumnSyntaxTree';
 import { RelationalOperator } from './lexeme/relational';
-import { IColumn } from 'dash-table/components/Table/props';
+import { IColumn, Case } from 'dash-table/components/Table/props';
 
 export const getMultiColumnQueryString = (
     asts: SingleColumnSyntaxTree[]
@@ -17,7 +17,8 @@ export const getMultiColumnQueryString = (
 
 export const getSingleColumnMap = (
     ast: MultiColumnsSyntaxTree,
-    columns: IColumn[]
+    columns: IColumn[],
+    filter_case: Case
 ) => {
     if (!ast.isValid) {
         return;
@@ -39,7 +40,7 @@ export const getSingleColumnMap = (
                 throw new Error(`column ${sanitizedColumnId} not found`);
             }
 
-            map.set(sanitizedColumnId, new SingleColumnSyntaxTree(s.value, column));
+            map.set(sanitizedColumnId, new SingleColumnSyntaxTree(s.value, column, filter_case));
         } else if (s.lexeme.type === LexemeType.RelationalOperator && s.left && s.right) {
             const sanitizedColumnId = s.left.lexeme.present ? s.left.lexeme.present(s.left) : s.left.value;
 
@@ -49,9 +50,9 @@ export const getSingleColumnMap = (
             }
 
             if (s.lexeme.present && s.lexeme.present(s) === RelationalOperator.Equal) {
-                map.set(sanitizedColumnId, new SingleColumnSyntaxTree(`${s.right.value}`, column));
+                map.set(sanitizedColumnId, new SingleColumnSyntaxTree(`${s.right.value}`, column, filter_case));
             } else {
-                map.set(sanitizedColumnId, new SingleColumnSyntaxTree(`${s.value} ${s.right.value}`, column));
+                map.set(sanitizedColumnId, new SingleColumnSyntaxTree(`${s.value} ${s.right.value}`, column, filter_case));
             }
         }
     }, statements);

--- a/src/dash-table/syntax-tree/lexeme/relational.ts
+++ b/src/dash-table/syntax-tree/lexeme/relational.ts
@@ -40,7 +40,21 @@ export enum RelationalOperator {
     GreaterThan = '>',
     LessOrEqual = '<=',
     LessThan = '<',
-    NotEqual = '!='
+    NotEqual = '!=',
+    IContains = 'icontains',
+    IEqual = 'i=',
+    IGreaterOrEqual = 'i>=',
+    IGreaterThan = 'i>',
+    ILessOrEqual = 'i<=',
+    ILessThan = 'i<',
+    INotEqual = 'i!=',
+    SContains = 'scontains',
+    SEqual = 's=',
+    SGreaterOrEqual = 's>=',
+    SGreaterThan = 's>',
+    SLessOrEqual = 's<=',
+    SLessThan = 's<',
+    SNotEqual = 's!='
 }
 
 const LEXEME_BASE = {
@@ -57,6 +71,7 @@ export const contains: IUnboundedLexeme = R.merge({
         op.toString().indexOf(exp.toString()) !== -1
     ),
     subType: RelationalOperator.Contains,
+    case: 'default',
     regexp: /^((contains)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -68,6 +83,7 @@ export const equal: IUnboundedLexeme = R.merge({
             op === exp
     ),
     subType: RelationalOperator.Equal,
+    case: 'default',
     regexp: /^(=|(eq)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -75,6 +91,7 @@ export const equal: IUnboundedLexeme = R.merge({
 export const greaterOrEqual: IUnboundedLexeme = R.merge({
     evaluate: relationalEvaluator(([op, exp]) => op >= exp),
     subType: RelationalOperator.GreaterOrEqual,
+    case: 'default',
     regexp: /^(>=|(ge)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -82,6 +99,7 @@ export const greaterOrEqual: IUnboundedLexeme = R.merge({
 export const greaterThan: IUnboundedLexeme = R.merge({
     evaluate: relationalEvaluator(([op, exp]) => op > exp),
     subType: RelationalOperator.GreaterThan,
+    case: 'default',
     regexp: /^(>|(gt)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -111,6 +129,7 @@ export const dateStartsWith: IUnboundedLexeme = R.merge({
 export const lessOrEqual: IUnboundedLexeme = R.merge({
     evaluate: relationalEvaluator(([op, exp]) => op <= exp),
     subType: RelationalOperator.LessOrEqual,
+    case: 'default',
     regexp: /^(<=|(le)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -118,6 +137,7 @@ export const lessOrEqual: IUnboundedLexeme = R.merge({
 export const lessThan: IUnboundedLexeme = R.merge({
     evaluate: relationalEvaluator(([op, exp]) => op < exp),
     subType: RelationalOperator.LessThan,
+    case: 'default',
     regexp: /^(<|(lt)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
@@ -125,6 +145,180 @@ export const lessThan: IUnboundedLexeme = R.merge({
 export const notEqual: IUnboundedLexeme = R.merge({
     evaluate: relationalEvaluator(([op, exp]) => op !== exp),
     subType: RelationalOperator.NotEqual,
+    case: 'default',
     regexp: /^(!=|(ne)(?=\s|$))/i,
     regexpMatch: 1
 }, LEXEME_BASE);
+
+export const icontains: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        !R.isNil(exp) &&
+        !R.isNil(op) &&
+        (R.type(exp) === 'String' || R.type(op) === 'String') &&
+        op.toString().toLowerCase().indexOf(exp.toString().toLowerCase()) !== -1
+    ),
+    subType: RelationalOperator.IContains,
+    case: 'insensitive',
+    regexp: /^((icontains)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const iequal: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op === +exp :
+            op.toLowerCase() === exp.toLowerCase()
+    ),
+    subType: RelationalOperator.IEqual,
+    case: 'insensitive',
+    regexp: /^(i=|(ieq)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const igreaterOrEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op >= +exp :
+            op.toLowerCase() >= exp.toLowerCase()),
+    subType: RelationalOperator.IGreaterOrEqual,
+    case: 'insensitive',
+    regexp: /^(i>=|(ige)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const igreaterThan: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op > +exp :
+            op.toLowerCase() > exp.toLowerCase()),
+    subType: RelationalOperator.IGreaterThan,
+    case: 'insensitive',
+    regexp: /^(i>|(igt)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const ilessOrEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op <= +exp :
+            op.toLowerCase() <= exp.toLowerCase()),
+    subType: RelationalOperator.ILessOrEqual,
+    case: 'insensitive',
+    regexp: /^(i<=|(ile)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const ilessThan: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op < +exp :
+            op.toLowerCase() < exp.toLowerCase()),
+    subType: RelationalOperator.ILessThan,
+    case: 'insensitive',
+    regexp: /^(i<|(ilt)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const inotEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op !== +exp :
+            op.toLowerCase() !== exp.toLowerCase()),
+    subType: RelationalOperator.INotEqual,
+    case: 'insensitive',
+    regexp: /^(i!=|(ine)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const scontains: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        !R.isNil(exp) &&
+        !R.isNil(op) &&
+        (R.type(exp) === 'String' || R.type(op) === 'String') &&
+        op.toString().indexOf(exp.toString()) !== -1
+    ),
+    subType: RelationalOperator.SContains,
+    case: 'insensitive',
+    regexp: /^((scontains)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const sequal: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op === +exp :
+            op === exp
+    ),
+    sType: RelationalOperator.SEqual,
+    case: 'insensitive',
+    regexp: /^(s=|(seq)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const sgreaterOrEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op >= +exp :
+            op >= exp),
+    subType: RelationalOperator.SGreaterOrEqual,
+    case: 'sensitive',
+    regexp: /^(s>=|(sge)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const sgreaterThan: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op > +exp :
+            op > exp),
+    subType: RelationalOperator.SGreaterThan,
+    case: 'sensitive',
+    regexp: /^(s>|(sgt)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const slessOrEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op <= +exp :
+            op <= exp),
+    subType: RelationalOperator.SLessOrEqual,
+    case: 'sensitive',
+    regexp: /^(s<=|(sle)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const slessThan: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op < +exp :
+            op < exp),
+    subType: RelationalOperator.SLessThan,
+    case: 'sensitive',
+    regexp: /^(s<|(slt)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const snotEqual: IUnboundedLexeme = R.merge({
+    evaluate: relationalEvaluator(([op, exp]) =>
+        (isNumeric(op) && isNumeric(exp)) ?
+            +op !== +exp :
+            op !== exp),
+    subType: RelationalOperator.SNotEqual,
+    case: 'sensitive',
+    regexp: /^(s!=|(sne)(?=\s|$))/i,
+    regexpMatch: 1
+}, LEXEME_BASE);
+
+export const CaseMapping: Map<RelationalOperator, {
+    lexeme: IUnboundedLexeme;
+    value?: string;
+}> = new Map([
+    [RelationalOperator.Contains, { lexeme: icontains, value: 'icontains' }],
+    [RelationalOperator.Equal, { lexeme: iequal, value: 'i=' }],
+    [RelationalOperator.GreaterOrEqual, { lexeme: igreaterOrEqual, value: 'i>=' }],
+    [RelationalOperator.GreaterThan, { lexeme: igreaterThan, value: 'i>' }],
+    [RelationalOperator.LessOrEqual, { lexeme: ilessOrEqual, value: 'i<=' }],
+    [RelationalOperator.LessThan, { lexeme: ilessThan, value: 'i<' }],
+    [RelationalOperator.NotEqual, { lexeme: inotEqual, value: 'i!=' }]
+]);

--- a/src/dash-table/syntax-tree/lexeme/relational.ts
+++ b/src/dash-table/syntax-tree/lexeme/relational.ts
@@ -63,7 +63,7 @@ const LEXEME_BASE = {
     type: LexemeType.RelationalOperator
 };
 
-export const contains: IUnboundedLexeme = R.merge({
+export const contains: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         !R.isNil(exp) &&
         !R.isNil(op) &&
@@ -76,7 +76,7 @@ export const contains: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const equal: IUnboundedLexeme = R.merge({
+export const equal: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op === +exp :
@@ -88,7 +88,7 @@ export const equal: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const greaterOrEqual: IUnboundedLexeme = R.merge({
+export const greaterOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => op >= exp),
     subType: RelationalOperator.GreaterOrEqual,
     case: 'default',
@@ -96,7 +96,7 @@ export const greaterOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const greaterThan: IUnboundedLexeme = R.merge({
+export const greaterThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => op > exp),
     subType: RelationalOperator.GreaterThan,
     case: 'default',
@@ -108,7 +108,7 @@ const DATE_OPTIONS: IDateValidation = {
     allow_YY: true
 };
 
-export const dateStartsWith: IUnboundedLexeme = R.merge({
+export const dateStartsWith: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => {
         op = typeof op === 'number' ? op.toString() : op;
         exp = typeof exp === 'number' ? exp.toString() : exp;
@@ -126,7 +126,7 @@ export const dateStartsWith: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const lessOrEqual: IUnboundedLexeme = R.merge({
+export const lessOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => op <= exp),
     subType: RelationalOperator.LessOrEqual,
     case: 'default',
@@ -134,7 +134,7 @@ export const lessOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const lessThan: IUnboundedLexeme = R.merge({
+export const lessThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => op < exp),
     subType: RelationalOperator.LessThan,
     case: 'default',
@@ -142,7 +142,7 @@ export const lessThan: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const notEqual: IUnboundedLexeme = R.merge({
+export const notEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) => op !== exp),
     subType: RelationalOperator.NotEqual,
     case: 'default',
@@ -150,7 +150,7 @@ export const notEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const icontains: IUnboundedLexeme = R.merge({
+export const icontains: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         !R.isNil(exp) &&
         !R.isNil(op) &&
@@ -163,7 +163,7 @@ export const icontains: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const iequal: IUnboundedLexeme = R.merge({
+export const iequal: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op === +exp :
@@ -175,7 +175,7 @@ export const iequal: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const igreaterOrEqual: IUnboundedLexeme = R.merge({
+export const igreaterOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op >= +exp :
@@ -186,7 +186,7 @@ export const igreaterOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const igreaterThan: IUnboundedLexeme = R.merge({
+export const igreaterThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op > +exp :
@@ -197,7 +197,7 @@ export const igreaterThan: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const ilessOrEqual: IUnboundedLexeme = R.merge({
+export const ilessOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op <= +exp :
@@ -208,7 +208,7 @@ export const ilessOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const ilessThan: IUnboundedLexeme = R.merge({
+export const ilessThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op < +exp :
@@ -219,7 +219,7 @@ export const ilessThan: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const inotEqual: IUnboundedLexeme = R.merge({
+export const inotEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op !== +exp :
@@ -230,7 +230,7 @@ export const inotEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const scontains: IUnboundedLexeme = R.merge({
+export const scontains: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         !R.isNil(exp) &&
         !R.isNil(op) &&
@@ -243,7 +243,7 @@ export const scontains: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const sequal: IUnboundedLexeme = R.merge({
+export const sequal: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op === +exp :
@@ -255,7 +255,7 @@ export const sequal: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const sgreaterOrEqual: IUnboundedLexeme = R.merge({
+export const sgreaterOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op >= +exp :
@@ -266,7 +266,7 @@ export const sgreaterOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const sgreaterThan: IUnboundedLexeme = R.merge({
+export const sgreaterThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op > +exp :
@@ -277,7 +277,7 @@ export const sgreaterThan: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const slessOrEqual: IUnboundedLexeme = R.merge({
+export const slessOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op <= +exp :
@@ -288,7 +288,7 @@ export const slessOrEqual: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const slessThan: IUnboundedLexeme = R.merge({
+export const slessThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op < +exp :
@@ -299,7 +299,7 @@ export const slessThan: IUnboundedLexeme = R.merge({
     regexpMatch: 1
 }, LEXEME_BASE);
 
-export const snotEqual: IUnboundedLexeme = R.merge({
+export const snotEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op !== +exp :

--- a/src/dash-table/syntax-tree/lexeme/relational.ts
+++ b/src/dash-table/syntax-tree/lexeme/relational.ts
@@ -167,7 +167,7 @@ export const iequal: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op === +exp :
-            op.toLowerCase() === exp.toLowerCase()
+            op.toString().toLowerCase() === exp.toString().toLowerCase()
     ),
     subType: RelationalOperator.IEqual,
     case: 'insensitive',
@@ -179,7 +179,7 @@ export const igreaterOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op >= +exp :
-            op.toLowerCase() >= exp.toLowerCase()),
+            op.toString().toLowerCase() >= exp.toString().toLowerCase()),
     subType: RelationalOperator.IGreaterOrEqual,
     case: 'insensitive',
     regexp: /^(i>=|(ige)(?=\s|$))/i,
@@ -190,7 +190,7 @@ export const igreaterThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op > +exp :
-            op.toLowerCase() > exp.toLowerCase()),
+            op.toString().toLowerCase() > exp.toString().toLowerCase()),
     subType: RelationalOperator.IGreaterThan,
     case: 'insensitive',
     regexp: /^(i>|(igt)(?=\s|$))/i,
@@ -201,7 +201,7 @@ export const ilessOrEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op <= +exp :
-            op.toLowerCase() <= exp.toLowerCase()),
+            op.toString().toLowerCase() <= exp.toString().toLowerCase()),
     subType: RelationalOperator.ILessOrEqual,
     case: 'insensitive',
     regexp: /^(i<=|(ile)(?=\s|$))/i,
@@ -212,7 +212,7 @@ export const ilessThan: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op < +exp :
-            op.toLowerCase() < exp.toLowerCase()),
+            op.toString().toLowerCase() < exp.toString().toLowerCase()),
     subType: RelationalOperator.ILessThan,
     case: 'insensitive',
     regexp: /^(i<|(ilt)(?=\s|$))/i,
@@ -223,7 +223,7 @@ export const inotEqual: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(([op, exp]) =>
         (isNumeric(op) && isNumeric(exp)) ?
             +op !== +exp :
-            op.toLowerCase() !== exp.toLowerCase()),
+            op.toString().toLowerCase() !== exp.toString().toLowerCase()),
     subType: RelationalOperator.INotEqual,
     case: 'insensitive',
     regexp: /^(i!=|(ine)(?=\s|$))/i,

--- a/src/dash-table/syntax-tree/lexeme/unary.ts
+++ b/src/dash-table/syntax-tree/lexeme/unary.ts
@@ -65,47 +65,47 @@ export const not: IUnboundedLexeme = {
     }
 };
 
-export const isBool: IUnboundedLexeme = R.merge({
+export const isBool: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'boolean'),
     regexp: /^(is bool)/i
 }, LEXEME_BASE);
 
-export const isEven: IUnboundedLexeme = R.merge({
+export const isEven: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'number' && opValue % 2 === 0),
     regexp: /^(is even)/i
 }, LEXEME_BASE);
 
-export const isBlank: IUnboundedLexeme = R.merge({
+export const isBlank: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => opValue === undefined || opValue === null || opValue === ''),
     regexp: /^(is blank)/i
 }, LEXEME_BASE);
 
-export const isNil: IUnboundedLexeme = R.merge({
+export const isNil: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => opValue === undefined || opValue === null),
     regexp: /^(is nil)/i
 }, LEXEME_BASE);
 
-export const isNum: IUnboundedLexeme = R.merge({
+export const isNum: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'number'),
     regexp: /^(is num)/i
 }, LEXEME_BASE);
 
-export const isObject: IUnboundedLexeme = R.merge({
+export const isObject: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => opValue !== null && typeof opValue === 'object'),
     regexp: /^(is object)/i
 }, LEXEME_BASE);
 
-export const isOdd: IUnboundedLexeme = R.merge({
+export const isOdd: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'number' && opValue % 2 === 1),
     regexp: /^(is odd)/i
 }, LEXEME_BASE);
 
-export const isPrime: IUnboundedLexeme = R.merge({
+export const isPrime: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'number' && checkPrimality(opValue)),
     regexp: /^(is prime)/i
 }, LEXEME_BASE);
 
-export const isStr: IUnboundedLexeme = R.merge({
+export const isStr: IUnboundedLexeme = R.mergeRight({
     evaluate: relationalEvaluator(opValue => typeof opValue === 'string'),
     regexp: /^(is str)/i
 }, LEXEME_BASE);

--- a/src/dash-table/syntax-tree/lexicon/column.ts
+++ b/src/dash-table/syntax-tree/lexicon/column.ts
@@ -11,7 +11,21 @@ import {
     greaterThan,
     lessOrEqual,
     lessThan,
-    notEqual
+    notEqual,
+    icontains,
+    iequal,
+    igreaterOrEqual,
+    igreaterThan,
+    ilessOrEqual,
+    ilessThan,
+    inotEqual,
+    scontains,
+    sequal,
+    sgreaterOrEqual,
+    sgreaterThan,
+    slessOrEqual,
+    slessThan,
+    snotEqual
 } from '../lexeme/relational';
 import {
     isBlank,
@@ -40,7 +54,21 @@ const lexicon: ILexeme[] = [
         greaterThan,
         lessOrEqual,
         lessThan,
-        notEqual
+        notEqual,
+        icontains,
+        iequal,
+        igreaterOrEqual,
+        igreaterThan,
+        ilessOrEqual,
+        ilessThan,
+        inotEqual,
+        scontains,
+        sequal,
+        sgreaterOrEqual,
+        sgreaterThan,
+        slessOrEqual,
+        slessThan,
+        snotEqual
     ].map(op => ({
         ...op,
         if: ifLeading,

--- a/src/dash-table/syntax-tree/lexicon/columnMulti.ts
+++ b/src/dash-table/syntax-tree/lexicon/columnMulti.ts
@@ -16,7 +16,21 @@ import {
     greaterThan,
     lessOrEqual,
     lessThan,
-    notEqual
+    notEqual,
+    icontains,
+    iequal,
+    igreaterOrEqual,
+    igreaterThan,
+    ilessOrEqual,
+    ilessThan,
+    inotEqual,
+    scontains,
+    sequal,
+    sgreaterOrEqual,
+    sgreaterThan,
+    slessOrEqual,
+    slessThan,
+    snotEqual
 } from '../lexeme/relational';
 import {
     isBlank,
@@ -51,7 +65,21 @@ const lexicon: ILexeme[] = [
         greaterThan,
         lessOrEqual,
         lessThan,
-        notEqual
+        notEqual,
+        icontains,
+        iequal,
+        igreaterOrEqual,
+        igreaterThan,
+        ilessOrEqual,
+        ilessThan,
+        inotEqual,
+        scontains,
+        sequal,
+        sgreaterOrEqual,
+        sgreaterThan,
+        slessOrEqual,
+        slessThan,
+        snotEqual
     ].map(op => ({
         ...op,
         if: ifRelationalOperator,

--- a/src/dash-table/syntax-tree/lexicon/query.ts
+++ b/src/dash-table/syntax-tree/lexicon/query.ts
@@ -24,7 +24,21 @@ import {
     greaterThan,
     lessOrEqual,
     lessThan,
-    notEqual
+    notEqual,
+    icontains,
+    iequal,
+    igreaterOrEqual,
+    igreaterThan,
+    ilessOrEqual,
+    ilessThan,
+    inotEqual,
+    scontains,
+    sequal,
+    sgreaterOrEqual,
+    sgreaterThan,
+    slessOrEqual,
+    slessThan,
+    snotEqual
 } from '../lexeme/relational';
 import {
     isBlank,
@@ -84,7 +98,21 @@ const lexicon: ILexeme[] = [
         greaterThan,
         lessOrEqual,
         lessThan,
-        notEqual
+        notEqual,
+        icontains,
+        iequal,
+        igreaterOrEqual,
+        igreaterThan,
+        ilessOrEqual,
+        ilessThan,
+        inotEqual,
+        scontains,
+        sequal,
+        sgreaterOrEqual,
+        sgreaterThan,
+        slessOrEqual,
+        slessThan,
+        snotEqual
     ].map(op => ({
         ...op,
         if: ifRelationalOperator,

--- a/tests/cypress/src/DashTable.ts
+++ b/tests/cypress/src/DashTable.ts
@@ -40,6 +40,10 @@ export class DashTableHelper {
         return cy.get(`#${this.id} ${getSelector(editable)} tbody tr th.dash-filter[data-dash-column="${column}"]`);
     }
 
+    public getFilterCaseById(column: string, editable: State = State.Ready) {
+        return this.getFilterById(column, editable).within(() => cy.get('input[type=button]'));
+    }
+
     public getHeader(row: number, column: number, editable: State = State.Ready) {
         return cy.get(`#${this.id} ${getSelector(editable)} tbody tr th.dash-header.column-${column}`).eq(row);
     }

--- a/tests/cypress/tests/server/select_props_test.ts
+++ b/tests/cypress/tests/server/select_props_test.ts
@@ -137,11 +137,11 @@ describe('select row', () => {
         });
 
         it('selection props are correct, with filter', () => {
-            DashTable.getSelect(0).within(() => cy.get('input').click());
-            DashTable.getSelect(1).within(() => cy.get('input').click());
-            DashTable.getSelect(2).within(() => cy.get('input').click());
+            DashTable.getSelect(0).within(() => cy.get('input[type=text]').click());
+            DashTable.getSelect(1).within(() => cy.get('input[type=text]').click());
+            DashTable.getSelect(2).within(() => cy.get('input[type=text]').click());
 
-            cy.get('tr th.column-0.dash-filter input').type(`is even${Key.Enter}`);
+            cy.get('tr th.column-0.dash-filter input[type=text]').type(`is even${Key.Enter}`);
 
             // filtered-out data is still selected
             expectArray('#selected_rows_container', [0, 1, 2]);
@@ -157,13 +157,13 @@ describe('select row', () => {
         });
 
         it('selection props are correct, with filter & sort', () => {
-            DashTable.getSelect(0).within(() => cy.get('input').click());
-            DashTable.getSelect(1).within(() => cy.get('input').click());
+            DashTable.getSelect(0).within(() => cy.get('input[type=text]').click());
+            DashTable.getSelect(1).within(() => cy.get('input[type=text]').click());
 
             DashTable.getCell(3, 1).click();
             expectCellSelection([3], [3003], [1], [1]);
 
-            cy.get('tr th.column-0.dash-filter input').type(`is even${Key.Enter}`);
+            cy.get('tr th.column-0.dash-filter input[type=text]').type(`is even${Key.Enter}`);
 
             expectCellSelection([]);
 

--- a/tests/cypress/tests/standalone/filtering_test.ts
+++ b/tests/cypress/tests/standalone/filtering_test.ts
@@ -189,4 +189,20 @@ describe('filter', () => {
         DashTable.getFilterById('ddd').within(() => cy.get('input').should('have.value', ''));
         DashTable.getFilterById('eee').within(() => cy.get('input').should('have.value', ''));
     });
+
+    it.only('sets column filter to case insensitive', () => {
+        let cell_0;
+
+        DashTable.getCellById(0, 'bbb')
+            .within(() => cy.get('.Select-value-label')
+                .then($el => cell_0 = $el[0].innerHTML));
+
+        DashTable.getFilterCaseById('bbb').click();
+        DashTable.getFilterById('bbb').click();
+        DOM.focused.type(`wet`);
+        DashTable.getFilterById('ggg').click();
+        DashTable.getCellById(0, 'bbb').within(() => cy.get('.Select-value-label').should('have.html', cell_0));
+        DashTable.getFilterCaseById('bbb').click();
+        cy.get('.row-1').within(() => cy.get('tr').should('not.exist'));
+    });
 });

--- a/tests/cypress/tests/unit/query_syntactic_tree_test.ts
+++ b/tests/cypress/tests/unit/query_syntactic_tree_test.ts
@@ -599,7 +599,96 @@ describe('Query Syntax Tree', () => {
             const tree = new QuerySyntaxTree('{a}<=5');
             expect(tree.isValid).to.equal(true);
             expect(tree.evaluate({ a: 4 })).to.equal(true);
+        });
 
+        it('can do case insensitive equality (i=) test', () => {
+            const tree = new QuerySyntaxTree('{a} i= "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
+        });
+
+        it('can do case insensitive equality (ieq) test', () => {
+            const tree = new QuerySyntaxTree('{a} ieq "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
+        });
+
+        it('can do case insensitive difference (ine) test', () => {
+            const tree = new QuerySyntaxTree('{a} ine "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(false);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(false);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(true);
+        });
+
+        it('can do case insensitive difference (i!=) test', () => {
+            const tree = new QuerySyntaxTree('{a} i!= "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(false);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(false);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(true);
+        });
+
+        it('can do case insensitive icontains (icontains) test', () => {
+            const tree = new QuerySyntaxTree('{a} icontains v');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc V' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
+        });
+
+        it('can do case sensitive equality (s=) test', () => {
+            const tree = new QuerySyntaxTree('{a} s= "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(false);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
+        });
+
+        it('can do case sensitive equality (seq) test', () => {
+            const tree = new QuerySyntaxTree('{a} seq "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(false);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
+        });
+
+        it('can do case sensitive difference (sne) test', () => {
+            const tree = new QuerySyntaxTree('{a} sne "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(false);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(true);
+        });
+
+        it('can do case sensitive difference (s!=) test', () => {
+            const tree = new QuerySyntaxTree('{a} s!= "abc v"');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(false);
+            expect(tree.evaluate({ a: 'AbC V' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(true);
+        });
+
+        it('can do case sensitive scontains (scontains) test', () => {
+            const tree = new QuerySyntaxTree('{a} scontains v');
+
+            expect(tree.isValid).to.equal(true);
+            expect(tree.evaluate({ a: 'abc v' })).to.equal(true);
+            expect(tree.evaluate({ a: 'abc V' })).to.equal(false);
+            expect(tree.evaluate({ a: 'abc w' })).to.equal(false);
         });
     });
 });

--- a/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
+++ b/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
@@ -29,34 +29,46 @@ const COLUMN_UNDEFINED: SingleColumnConfig = {
     type: undefined
 };
 
+const COLUMN_CASE_INSENSITIVE: SingleColumnConfig = {
+    id: 'a',
+    type: ColumnType.Text,
+    filter_case_insensitive: true
+};
+
+const COLUMN_CASE_SENSITIVE: SingleColumnConfig = {
+    id: 'a',
+    type: ColumnType.Text,
+    filter_case_sensitive: true
+};
+
 describe('Single Column Syntax Tree', () => {
     it('cannot have operand', () => {
-        const tree = new SingleColumnSyntaxTree('{a} <= 1', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('{a} <= 1', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('cannot have binary dangle', () => {
-        const tree = new SingleColumnSyntaxTree('<=', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('<=', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('cannot be unary + expression', () => {
-        const tree = new SingleColumnSyntaxTree('is prime "a"', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('is prime "a"', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('can be empty', () => {
-        const tree = new SingleColumnSyntaxTree('', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 0 })).to.equal(true);
     });
 
     it('can be binary + expression', () => {
-        const tree = new SingleColumnSyntaxTree('<= 1', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('<= 1', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 0 })).to.equal(true);
@@ -66,7 +78,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be unary', () => {
-        const tree = new SingleColumnSyntaxTree('is prime', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('is prime', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 5 })).to.equal(true);
@@ -76,7 +88,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be expression with undefined column type', () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: '1' })).to.equal(true);
@@ -88,7 +100,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be expression with numeric column type', () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 1 })).to.equal(true);
@@ -98,7 +110,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it.only('can be permissive value expression', () => {
-        const tree = new SingleColumnSyntaxTree('Hello world', COLUMN_TEXT, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('Hello world', COLUMN_TEXT, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
@@ -107,25 +119,25 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('`undefined` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_UNDEFINED, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_UNDEFINED, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('`any` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_ANY, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_ANY, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('`numeric` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_NUMERIC, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_NUMERIC, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('can be expression with text column type', () => {
-        const tree = new SingleColumnSyntaxTree('"1"', COLUMN_TEXT, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('"1"', COLUMN_TEXT, Case.Sensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 1 })).to.equal(true);
@@ -138,7 +150,7 @@ describe('Single Column Syntax Tree', () => {
 
     ['1975', '"1975"'].forEach(value => {
         it(`can be expression '${value}' with datetime column type`, () => {
-            const tree = new SingleColumnSyntaxTree(value, COLUMN_DATE, Case.Insensitive);
+            const tree = new SingleColumnSyntaxTree(value, COLUMN_DATE, Case.Sensitive);
 
             expect(tree.evaluate({ a: 1975 })).to.equal(true);
             expect(tree.evaluate({ a: '1975' })).to.equal(true);
@@ -160,7 +172,7 @@ describe('Single Column Syntax Tree', () => {
         { type: COLUMN_TEXT, name: 'text' }
     ].forEach(({ type, name }) => {
         it(`returns the correct relational operator lexeme for '${name}' column type`, () => {
-            const tree = new SingleColumnSyntaxTree('1', type, Case.Insensitive);
+            const tree = new SingleColumnSyntaxTree('1', type, Case.Sensitive);
             const structure = tree.toStructure();
 
             expect(tree.toQueryString()).to.equal('{a} contains 1');
@@ -189,7 +201,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it(`returns the correct relational operator lexeme for 'date' column type`, () => {
-        const tree = new SingleColumnSyntaxTree('1975', COLUMN_DATE, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('1975', COLUMN_DATE, Case.Sensitive);
         const structure = tree.toStructure();
 
         expect(tree.toQueryString()).to.equal('{a} datestartswith 1975');
@@ -217,7 +229,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it(`returns the correct relational operator lexeme for 'numeric' column type`, () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Insensitive);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Default);
         const structure = tree.toStructure();
 
         expect(tree.toQueryString()).to.equal('{a} = 1');
@@ -242,5 +254,41 @@ describe('Single Column Syntax Tree', () => {
                 expect(structure.right.value).to.equal(1);
             }
         }
+    });
+
+    it('can have case-insensitive column', () => {
+        const tree = new SingleColumnSyntaxTree('= Hello world', COLUMN_CASE_INSENSITIVE, Case.Default);
+
+        expect(tree.isValid).to.equal(true);
+        expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
+        expect(tree.evaluate({ a: 'Helloworld' })).to.equal(false);
+        expect(tree.toQueryString()).to.equal('{a} i= "Hello world"');
+    });
+
+    it('can have forced case-sensitive column in case-insensitive table', () => {
+        const tree = new SingleColumnSyntaxTree('= Hello world', COLUMN_CASE_SENSITIVE, Case.Insensitive);
+
+        expect(tree.isValid).to.equal(true);
+        expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
+        expect(tree.evaluate({ a: 'Helloworld' })).to.equal(false);
+        expect(tree.toQueryString()).to.equal('{a} = "Hello world"');
+    });
+
+    it('can have forced case-sensitive operator in case-insensitive column', () => {
+        const tree = new SingleColumnSyntaxTree('c= Hello world', COLUMN_CASE_INSENSITIVE, Case.Default);
+
+        expect(tree.isValid).to.equal(true);
+        expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
+        expect(tree.evaluate({ a: 'Helloworld' })).to.equal(false);
+        expect(tree.toQueryString()).to.equal('{a} = "Hello world"');
+    });
+
+    it('can have forced case-sensitive operator in case-insensitive table', () => {
+        const tree = new SingleColumnSyntaxTree('c= Hello world', COLUMN_CASE_SENSITIVE, Case.Insensitive);
+
+        expect(tree.isValid).to.equal(true);
+        expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
+        expect(tree.evaluate({ a: 'Helloworld' })).to.equal(false);
+        expect(tree.toQueryString()).to.equal('{a} = "Hello world"');
     });
 });

--- a/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
+++ b/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
@@ -1,5 +1,5 @@
 import { SingleColumnSyntaxTree } from 'dash-table/syntax-tree';
-import { ColumnType } from 'dash-table/components/Table/props';
+import { ColumnType, Case } from 'dash-table/components/Table/props';
 import { SingleColumnConfig } from 'dash-table/syntax-tree/SingleColumnSyntaxTree';
 import { RelationalOperator } from 'dash-table/syntax-tree/lexeme/relational';
 import { LexemeType } from 'core/syntax-tree/lexicon';
@@ -31,32 +31,32 @@ const COLUMN_UNDEFINED: SingleColumnConfig = {
 
 describe('Single Column Syntax Tree', () => {
     it('cannot have operand', () => {
-        const tree = new SingleColumnSyntaxTree('{a} <= 1', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('{a} <= 1', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('cannot have binary dangle', () => {
-        const tree = new SingleColumnSyntaxTree('<=', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('<=', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('cannot be unary + expression', () => {
-        const tree = new SingleColumnSyntaxTree('is prime "a"', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('is prime "a"', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(false);
     });
 
     it('can be empty', () => {
-        const tree = new SingleColumnSyntaxTree('', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 0 })).to.equal(true);
     });
 
     it('can be binary + expression', () => {
-        const tree = new SingleColumnSyntaxTree('<= 1', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('<= 1', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 0 })).to.equal(true);
@@ -66,7 +66,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be unary', () => {
-        const tree = new SingleColumnSyntaxTree('is prime', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('is prime', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 5 })).to.equal(true);
@@ -76,7 +76,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be expression with undefined column type', () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: '1' })).to.equal(true);
@@ -88,7 +88,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('can be expression with numeric column type', () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 1 })).to.equal(true);
@@ -98,7 +98,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it.only('can be permissive value expression', () => {
-        const tree = new SingleColumnSyntaxTree('Hello world', COLUMN_TEXT);
+        const tree = new SingleColumnSyntaxTree('Hello world', COLUMN_TEXT, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 'Hello world' })).to.equal(true);
@@ -107,25 +107,25 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it('`undefined` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_UNDEFINED);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_UNDEFINED, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('`any` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_ANY);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_ANY, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('`numeric` column type can use `contains`', () => {
-        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_NUMERIC);
+        const tree = new SingleColumnSyntaxTree('contains 1', COLUMN_NUMERIC, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
     });
 
     it('can be expression with text column type', () => {
-        const tree = new SingleColumnSyntaxTree('"1"', COLUMN_TEXT);
+        const tree = new SingleColumnSyntaxTree('"1"', COLUMN_TEXT, Case.Insensitive);
 
         expect(tree.isValid).to.equal(true);
         expect(tree.evaluate({ a: 1 })).to.equal(true);
@@ -138,7 +138,7 @@ describe('Single Column Syntax Tree', () => {
 
     ['1975', '"1975"'].forEach(value => {
         it(`can be expression '${value}' with datetime column type`, () => {
-            const tree = new SingleColumnSyntaxTree(value, COLUMN_DATE);
+            const tree = new SingleColumnSyntaxTree(value, COLUMN_DATE, Case.Insensitive);
 
             expect(tree.evaluate({ a: 1975 })).to.equal(true);
             expect(tree.evaluate({ a: '1975' })).to.equal(true);
@@ -160,7 +160,7 @@ describe('Single Column Syntax Tree', () => {
         { type: COLUMN_TEXT, name: 'text' }
     ].forEach(({ type, name }) => {
         it(`returns the correct relational operator lexeme for '${name}' column type`, () => {
-            const tree = new SingleColumnSyntaxTree('1', type);
+            const tree = new SingleColumnSyntaxTree('1', type, Case.Insensitive);
             const structure = tree.toStructure();
 
             expect(tree.toQueryString()).to.equal('{a} contains 1');
@@ -189,7 +189,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it(`returns the correct relational operator lexeme for 'date' column type`, () => {
-        const tree = new SingleColumnSyntaxTree('1975', COLUMN_DATE);
+        const tree = new SingleColumnSyntaxTree('1975', COLUMN_DATE, Case.Insensitive);
         const structure = tree.toStructure();
 
         expect(tree.toQueryString()).to.equal('{a} datestartswith 1975');
@@ -217,7 +217,7 @@ describe('Single Column Syntax Tree', () => {
     });
 
     it(`returns the correct relational operator lexeme for 'numeric' column type`, () => {
-        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC);
+        const tree = new SingleColumnSyntaxTree('1', COLUMN_NUMERIC, Case.Insensitive);
         const structure = tree.toStructure();
 
         expect(tree.toQueryString()).to.equal('{a} = 1');

--- a/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
+++ b/tests/cypress/tests/unit/single_column_syntactic_tree_test.ts
@@ -32,13 +32,13 @@ const COLUMN_UNDEFINED: SingleColumnConfig = {
 const COLUMN_CASE_INSENSITIVE: SingleColumnConfig = {
     id: 'a',
     type: ColumnType.Text,
-    filter_case_insensitive: true
+    filter_case: Case.Insensitive
 };
 
 const COLUMN_CASE_SENSITIVE: SingleColumnConfig = {
     id: 'a',
     type: ColumnType.Text,
-    filter_case_sensitive: true
+    filter_case: Case.Sensitive
 };
 
 describe('Single Column Syntax Tree', () => {

--- a/tests/visual/percy-storybook/Style.percy.tsx
+++ b/tests/visual/percy-storybook/Style.percy.tsx
@@ -357,7 +357,7 @@ storiesOf('DashTable/Style type condition', module)
     .add('paging', () => (<DataTable
         id='styling-20'
         data= {mock.data}
-        columns={ mock.columns.map((col: any) => R.merge(col, {
+        columns={ mock.columns.map((col: any) => R.mergeRight(col, {
             name: col.name,
             deletable: true
         }))}

--- a/tests/visual/percy-storybook/Width.empty.percy.tsx
+++ b/tests/visual/percy-storybook/Width.empty.percy.tsx
@@ -39,22 +39,22 @@ storiesOf('DashTable/Empty', module)
         {...props}
     />))
     .add('with column filters -- invalid query', () => (<DataTable
-        {...R.merge(props, {
+        {...R.mergeRight(props, {
             filter_query: '{a} !'
         })}
     />))
     .add('with column filters -- single query', () => (<DataTable
-        {...R.merge(props, {
+        {...R.mergeRight(props, {
             filter_query: '{a} ge 0'
         })}
     />))
     .add('with column filters -- multi query', () => (<DataTable
-        {...R.merge(props, {
+        {...R.mergeRight(props, {
             filter_query: '{a} ge 0 && {b} ge 0'
         })}
     />))
     .add('with column filters -- multi query, no data', () => (<DataTable
-        {...R.merge(props, {
+        {...R.mergeRight(props, {
             filter_query: '{a} gt 1000 && {b} gt 1000'
         })}
     />));


### PR DESCRIPTION
Closes #545
Implements case-insensitive filtering.

TODO:
- [x] Tests
- [x] Incorporate changes from https://github.com/plotly/dash-table/pull/612
- [x] GUI for filters
- [x] GUI for global filter
- [x] tests for GUI + percy tests
- [ ] Update https://dash.plot.ly/datatable/filtering with new operators, etc.