### PR TITLE
Remove VSCode config from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ NAMESPACE
 
 # misc
 .DS_Store
+.vscode
 .env.local
 .env.development.local
 .env.test.local

--- a/cspell.json
+++ b/cspell.json
@@ -1,7 +1,6 @@
 {
-    "tslint.jsEnable": true,
-    "cSpell.allowCompoundWords": true,
-    "cSpell.ignorePaths": [
+    "allowCompoundWords": true,
+    "ignorePaths": [
         "**/package.json",
         "**/package-lock.json",
         "**/node_modules/**",
@@ -10,15 +9,15 @@
         ".vscode",
         "typings"
     ],
-    "cSpell.ignoreRegExpList": [
+    "ignoreRegExpList": [
         "'"
     ],
-    "cSpell.language": "en",
-    "cSpell.diagnosticLevel": "Error",
-    "cSpell.languageSettings": [
+    "language": "en",
+    "diagnosticLevel": "Error",
+    "languageSettings": [
         { "languageId": "*", "dictionaries": ["fonts", "css", "html", "npm", "typescript", "python"]}
     ],
-    "cSpell.words": [
+    "words": [
         "Paginator",
         "atto",
         "corejs",


### PR DESCRIPTION
Fixes #610 

After this PR, developers using VSCode, would need to create their own project configuration. The only line that is needed is:

`"tslint.jsEnable": true`