### PR TITLE
description for setProps prop

### DIFF
--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -680,6 +680,9 @@ export const propTypes = {
         PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     ),
 
+    /**
+     * Dash-assigned callback that gets fired when the user makes changes.
+     */
     setProps: PropTypes.func,
 
     /**


### PR DESCRIPTION
just to remove the warning during build:

```
> dash-generate-components src/dash-table/dash/DataTable.js dash_table -p package-info.json && cp dash_table_base/** dash_table/ && dash-generate-components src/dash-table/dash/DataTable.js dash_table -p package-info.json --r-prefix 'dash'


Description for DataTable.setProps is missing!

Generated DataTable.py

Description for DataTable.setProps is missing!

Generated DataTable.py
Generated dashDataTable.R
```