### PR TITLE
Issue 611 - Hidden columns on copy/paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-
-- [#618](https://github.com/plotly/dash-table/issues/618) Fix a bug with keyboard navigation not
-working correctly in certain circumstances when the table contains `readonly` columns.
-
-- [#206](https://github.com/plotly/dash-table/issues/206) Fix a bug with copy/paste to and from
-column filters not working.
-
-- [#561](https://github.com/plotly/dash-table/issues/561) Fix an incorrect React PureComponent
-usage causing warnings in DevTools.
+- [#618](https://github.com/plotly/dash-table/issues/618) Fix a bug with keyboard navigation not working correctly in certain circumstances when the table contains `readonly` columns.
+- [#206](https://github.com/plotly/dash-table/issues/206) Fix a bug with copy/paste to and from column filters not working.
+- [#561](https://github.com/plotly/dash-table/issues/561) Fix an incorrect React PureComponent usage causing warnings in DevTools.
+- [#611](https://github.com/plotly/dash-table/issues/611) Fix a bug with copy/paste causing hidden columns to be removed from the table
 
 ## [4.4.0] - 2019-10-08
 ### Added

--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -587,6 +587,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
     onPaste = (e: any) => {
         const {
             active_cell,
+            columns,
             data,
             editable,
             filter_query,
@@ -606,6 +607,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
             e,
             active_cell,
             viewport.indices,
+            columns,
             visibleColumns,
             data,
             true,

--- a/src/dash-table/utils/TableClipboardHelper.ts
+++ b/src/dash-table/utils/TableClipboardHelper.ts
@@ -47,6 +47,7 @@ export default class TableClipboardHelper {
         activeCell: ICellCoordinates,
         derived_viewport_indices: number[],
         columns: Columns,
+        visibleColumns: Columns,
         data: Data,
         overflowColumns: boolean = true,
         overflowRows: boolean = true,
@@ -68,6 +69,7 @@ export default class TableClipboardHelper {
             activeCell,
             derived_viewport_indices,
             columns,
+            visibleColumns,
             data,
             overflowColumns,
             overflowRows

--- a/tests/cypress/tests/unit/clipboard_test.ts
+++ b/tests/cypress/tests/unit/clipboard_test.ts
@@ -3,13 +3,75 @@ import * as R from 'ramda';
 import applyClipboardToData from 'dash-table/utils/applyClipboardToData';
 
 describe('clipboard', () => {
+    const columns = ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: [] }));
+
+    describe('with hidden columns', () => {
+        const altColumns = [
+            'c1',
+            'c2'
+        ].map(id => ({ id: id, name: id, editable: true, sort_as_null: [] }));
+
+        describe('with column overflow', () => {
+            it('returns all columns, 1st column visible only', () => {
+                const altVisibleColumns = altColumns.slice(0, 1);
+
+                const res = applyClipboardToData(
+                    R.range(0, 2).map(value => [`${value}`, `${value + 1}`]),
+                    { row: 0, column: 0, column_id: '' },
+                    R.range(0, 1),
+                    altColumns,
+                    altVisibleColumns,
+                    R.range(0, 1).map(() => ({ c1: 'c1', c2: 'c2' })),
+                    true,
+                    true
+                );
+
+                expect(res).to.not.equal(undefined);
+
+                if (res) {
+                    expect(res.data.length).to.equal(2);
+                    expect(Object.entries(res.data[0]).length).to.equal(3);
+                    expect(res.columns.length).to.equal(3);
+                    expect(res.columns[0].id).to.equal('c1');
+                    expect(res.columns[2].id).to.equal('c2');
+                }
+            });
+        });
+
+        it('returns all columns, 2nd column visible only', () => {
+            const altVisibleColumns = altColumns.slice(-1);
+
+            const res = applyClipboardToData(
+                R.range(0, 2).map(value => [`${value}`, `${value + 1}`]),
+                { row: 0, column: 0, column_id: '' },
+                R.range(0, 1),
+                altColumns,
+                altVisibleColumns,
+                R.range(0, 1).map(() => ({ c1: 'c1', c2: 'c2' })),
+                true,
+                true
+            );
+
+            expect(res).to.not.equal(undefined);
+
+            if (res) {
+                expect(res.data.length).to.equal(2);
+                expect(Object.entries(res.data[0]).length).to.equal(3);
+                expect(res.columns.length).to.equal(3);
+                expect(res.columns[0].id).to.equal('c1');
+                expect(res.columns[1].id).to.equal('c2');
+            }
+        });
+    });
+
     describe('with column/row overflow allowed', () => {
         it('pastes one line at [0, 0] in one line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 1).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 1),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 1).map(() => ({ c1: 'c1' })),
                 true,
                 true
@@ -26,9 +88,10 @@ describe('clipboard', () => {
         it('pastes two lines at [0, 0] in one line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 2).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 1),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 1).map(() => ({ c1: 'c1' })),
                 true,
                 true
@@ -46,9 +109,10 @@ describe('clipboard', () => {
         it('pastes ten lines at [0, 0] in three line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 10).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 3),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 3).map(() => ({ c1: 'c1' })),
                 true,
                 true
@@ -67,9 +131,10 @@ describe('clipboard', () => {
         it('pastes ten lines at [1, 0] in three line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 10).map(value => [`${value}`]),
-                {row: 1, column: 0, column_id: ''},
+                { row: 1, column: 0, column_id: '' },
                 R.range(0, 3),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 3).map(() => ({ c1: 'c1' })),
                 true,
                 true
@@ -91,9 +156,10 @@ describe('clipboard', () => {
         it('pastes one line at [0, 0] in one line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 1).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 1),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 1).map(() => ({ c1: 'c1' })),
                 true,
                 false
@@ -110,9 +176,10 @@ describe('clipboard', () => {
         it('pastes two lines at [0, 0] in one line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 2).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 1),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 1).map(() => ({ c1: 'c1' })),
                 true,
                 false
@@ -129,9 +196,10 @@ describe('clipboard', () => {
         it('pastes ten lines at [0, 0] in three line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 10).map(value => [`${value}`]),
-                {row: 0, column: 0, column_id: ''},
+                { row: 0, column: 0, column_id: '' },
                 R.range(0, 3),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: []  })),
+                columns,
+                columns,
                 R.range(0, 3).map(() => ({ c1: 'c1' })),
                 true,
                 false
@@ -150,9 +218,10 @@ describe('clipboard', () => {
         it('pastes ten lines at [1, 0] in three line df', () => {
             const res = applyClipboardToData(
                 R.range(0, 10).map(value => [`${value}`]),
-                {row: 1, column: 0, column_id: ''},
+                { row: 1, column: 0, column_id: '' },
                 R.range(0, 3),
-                ['c1'].map(id => ({ id: id, name: id, editable: true, sort_as_null: [] })),
+                columns,
+                columns,
                 R.range(0, 3).map(() => ({ c1: 'c1' })),
                 true,
                 false


### PR DESCRIPTION
Fixes #611 

Similarly to what's being done elsewhere, the clipboard needs to take into consideration both the visible columns and all the available columns when handling a copy/paste operation.

The last visible column is used to determine placement and whether new columns are required, all columns are used to determine the final set of columns if new ones are needed and their final placement based on visible ones.

Added two tests to the clipboard to check the behavior when there are hidden columns.