### PR TITLE
Issue 206 - Filter copy/paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#618](https://github.com/plotly/dash-table/issues/618) Fix a bug with keyboard navigation not
 working correctly in certain circumstances when the table contains `readonly` columns.
 
+- [#206](https://github.com/plotly/dash-table/issues/206) Fix a bug with copy/paste to and from
+column filters not working.
+
 ## [4.4.0] - 2019-10-08
 ### Added
 [#546](https://github.com/plotly/dash-table/issues/546)

--- a/src/core/Clipboard.ts
+++ b/src/core/Clipboard.ts
@@ -25,10 +25,4 @@ export default class Clipboard {
 
         return value;
     }
-
-    public static clear() {
-        /*#if TEST_COPY_PASTE*/
-        Clipboard.value = '';
-        /*#endif*/
-    }
 }

--- a/src/core/Clipboard.ts
+++ b/src/core/Clipboard.ts
@@ -25,4 +25,10 @@ export default class Clipboard {
 
         return value;
     }
+
+    public static clear() {
+        /*#if TEST_COPY_PASTE*/
+        Clipboard.value = '';
+        /*#endif*/
+    }
 }

--- a/src/core/components/IsolatedInput/index.tsx
+++ b/src/core/components/IsolatedInput/index.tsx
@@ -4,6 +4,8 @@ import { KEY_CODES } from 'dash-table/utils/unicode';
 type Submit = (value: string | undefined) => void;
 
 interface IProps {
+    onCopy?: (e: any) => void;
+    onPaste?: (e: any) => void;
     placeholder?: string;
     updateOnBlur?: boolean;
     updateOnSubmit?: boolean;
@@ -84,6 +86,8 @@ export default class IsolatedInput extends PureComponent<IProps, IState> {
 
     render() {
         const {
+            onCopy,
+            onPaste,
             placeholder,
             updateOnBlur,
             updateOnSubmit
@@ -100,6 +104,8 @@ export default class IsolatedInput extends PureComponent<IProps, IState> {
             type='text'
             value={this.state.value || ''}
             onChange={this.handleChange}
+            onCopy={onCopy}
+            onPaste={onPaste}
             placeholder={placeholder}
             {...props}
         />);

--- a/src/dash-table/components/Filter/Column.tsx
+++ b/src/dash-table/components/Filter/Column.tsx
@@ -3,6 +3,7 @@ import React, { CSSProperties, PureComponent } from 'react';
 import IsolatedInput from 'core/components/IsolatedInput';
 
 import { ColumnId } from 'dash-table/components/Table/props';
+import TableClipboardHelper from 'dash-table/utils/TableClipboardHelper';
 
 type SetFilter = (ev: any) => void;
 
@@ -51,6 +52,13 @@ export default class ColumnFilter extends PureComponent<IColumnFilterProps, ISta
             style={style}
         >
             <IsolatedInput
+                onCopy={(e: any) => {
+                    e.stopPropagation();
+                    TableClipboardHelper.clearClipboard();
+                }}
+                onPaste={(e: any) => {
+                    e.stopPropagation();
+                }}
                 value={value}
                 placeholder={`filter data...`}
                 stopPropagation={true}

--- a/src/dash-table/utils/TableClipboardHelper.ts
+++ b/src/dash-table/utils/TableClipboardHelper.ts
@@ -42,6 +42,12 @@ export default class TableClipboardHelper {
         Clipboard.set(e, value);
     }
 
+    public static clearClipboard() {
+        Clipboard.clear();
+        TableClipboardHelper.lastLocalCopy = [];
+        TableClipboardHelper.localCopyWithoutHeaders = [];
+    }
+
     public static fromClipboard(
         ev: ClipboardEvent,
         activeCell: ICellCoordinates,

--- a/src/dash-table/utils/TableClipboardHelper.ts
+++ b/src/dash-table/utils/TableClipboardHelper.ts
@@ -43,7 +43,6 @@ export default class TableClipboardHelper {
     }
 
     public static clearClipboard() {
-        Clipboard.clear();
         TableClipboardHelper.lastLocalCopy = [];
         TableClipboardHelper.localCopyWithoutHeaders = [];
     }


### PR DESCRIPTION
Fixes #206 

Allow copy/paste from/to filter columns inputs.

**Note**: Sadly there's no good way to test this through Cypress. The table cell copy could be done because of the way the data is copied and pasted, could be shimmed with some tweaking. There's no clear path here.