### PR TITLE
Async table component

### DIFF
--- a/dash_table_base/__init__.py
+++ b/dash_table_base/__init__.py
@@ -60,6 +60,22 @@ _js_dist = [
         ).format(__version__),
         'namespace': package_name,
         'dynamic': True
+    },
+    {
+        'relative_package_path': 'async~table.js',
+        'external_url': (
+            'https://unpkg.com/dash-table@{}/dash_table/async~table.js'
+        ).format(__version__),
+        'namespace': package_name,
+        'async': True
+    },
+    {
+        'relative_package_path': 'async~table.js.map',
+        'external_url': (
+            'https://unpkg.com/dash-table@{}/dash_table/async~table.js.map'
+        ).format(__version__),
+        'namespace': package_name,
+        'dynamic': True
     }
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,6 +2246,12 @@
         }
       }
     },
+    "@plotly/dash-component-plugins": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@plotly/dash-component-plugins/-/dash-component-plugins-1.0.1.tgz",
+      "integrity": "sha512-z3KTahhLhIw3RZL49OOutyV8ePn2kZLCnMBoWYPy5sr55Yd2ghL7aDDyO1yseintG+RTm72n6UB35G++mvNbpA==",
+      "dev": true
+    },
     "@plotly/webpack-dash-dynamic-import": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@plotly/webpack-dash-dynamic-import/-/webpack-dash-dynamic-import-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@percy/storybook": "^3.2.0",
     "@plotly/dash-component-plugins": "^1.0.1",
-    "@plotly/webpack-dash-dynamic-import": "^1.0.0",
+    "@plotly/webpack-dash-dynamic-import": "^1.1.0",
     "@storybook/cli": "^5.1.11",
     "@storybook/react": "^5.1.11",
     "@types/d3-format": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@percy/storybook": "^3.2.0",
+    "@plotly/dash-component-plugins": "^1.0.1",
     "@plotly/webpack-dash-dynamic-import": "^1.0.0",
     "@storybook/cli": "^5.1.11",
     "@storybook/react": "^5.1.11",

--- a/src/dash-table/LazyLoader.ts
+++ b/src/dash-table/LazyLoader.ts
@@ -2,4 +2,8 @@ export default class LazyLoader {
     public static get xlsx() {
         return import(/* webpackChunkName: "export", webpackMode: "$${{mode}}" */ 'xlsx');
     }
+
+    public static table() {
+        return import(/* webpackChunkName: "table", webpackMode: "$${{mode}}" */ 'dash-table/dash/fragments/DataTable');
+    }
 }

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -1,14 +1,16 @@
 import * as R from 'ramda';
-import React, { Component } from 'react';
+import React, { Component, lazy } from 'react';
 import PropTypes from 'prop-types';
-
-import RealTable from 'dash-table/components/Table';
+import { asyncDecorator } from '@plotly/dash-component-plugins';
 
 import Logger from 'core/Logger';
 
 import genRandomId from 'dash-table/utils/generate';
 import isValidProps from './validate';
 import Sanitizer from './Sanitizer';
+import LazyLoader from 'dash-table/LazyLoader';
+
+const RealDataTable = asyncDecorator(DataTable, LazyLoader.table);
 
 /**
  * Dash DataTable is an interactive table component designed for
@@ -20,22 +22,12 @@ import Sanitizer from './Sanitizer';
  * is completely customizable through its properties.
  */
 export default class DataTable extends Component {
-    constructor(props) {
-        super(props);
-        let id;
-        this.getId = () => (id = id || genRandomId('table-'));
-        this.sanitizer = new Sanitizer();
-    }
-
     render() {
-        if (!isValidProps(this.props)) {
-            return (<div>Invalid props combination</div>);
-        }
-
-        const sanitizedProps = this.sanitizer.sanitize(this.props);
-        return this.props.id ?
-            (<RealTable {...sanitizedProps} />) :
-            (<RealTable {...sanitizedProps} id={this.getId()} />);
+        return (
+            <Suspense fallback={null}>
+                <RealDataTable {...this.props} />
+            </Suspense>
+        );
     }
 }
 

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import React, { Component, lazy } from 'react';
+import React, { Component, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { asyncDecorator } from '@plotly/dash-component-plugins';
 
@@ -9,8 +9,6 @@ import genRandomId from 'dash-table/utils/generate';
 import isValidProps from './validate';
 import Sanitizer from './Sanitizer';
 import LazyLoader from 'dash-table/LazyLoader';
-
-const RealDataTable = asyncDecorator(DataTable, LazyLoader.table);
 
 /**
  * Dash DataTable is an interactive table component designed for
@@ -30,6 +28,8 @@ export default class DataTable extends Component {
         );
     }
 }
+
+const RealDataTable = asyncDecorator(DataTable, LazyLoader.table);
 
 export const defaultProps = {
     page_action: 'native',

--- a/src/dash-table/dash/fragments/DataTable.js
+++ b/src/dash-table/dash/fragments/DataTable.js
@@ -1,0 +1,35 @@
+import * as R from 'ramda';
+import React, { Component } from 'react';
+
+import RealTable from 'dash-table/components/Table';
+
+import Logger from 'core/Logger';
+
+import genRandomId from 'dash-table/utils/generate';
+import isValidProps from '../validate';
+import Sanitizer from '../Sanitizer';
+
+import { propTypes, defaultProps } from '../DataTable';
+
+export default class DataTable extends Component {
+    constructor(props) {
+        super(props);
+        let id;
+        this.getId = () => (id = id || genRandomId('table-'));
+        this.sanitizer = new Sanitizer();
+    }
+
+    render() {
+        if (!isValidProps(this.props)) {
+            return (<div>Invalid props combination</div>);
+        }
+
+        const sanitizedProps = this.sanitizer.sanitize(this.props);
+        return this.props.id ?
+            (<RealTable {...sanitizedProps} />) :
+            (<RealTable {...sanitizedProps} id={this.getId()} />);
+    }
+}
+
+DataTable.defaultProps = defaultProps;
+DataTable.propTypes = propTypes;


### PR DESCRIPTION
Follow up to https://github.com/plotly/dash/pull/973 to be completed and `@plotly/webpack-dash-dynamic-import` to be updated / published in order to be completed.

Makes the entire table component async. As the table has side-effects (like the dcc.Graph), it needs to inform the renderer by using the `@plotly/dash-component-plugins` decorator.