### PR TITLE
Update naming of derived_filter_query_structure in derivedPropsHelper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- [#670](https://github.com/plotly/dash-table/pull/670) Fix a bug where `derived_filter_query_structure` was not getting updated properly
+
 ## [4.5.1] - 2019-11-14
 ### Fixed
 - [#637](https://github.com/plotly/dash-table/pull/637) Fix multiple issues

--- a/src/dash-table/components/Table/derivedPropsHelper.ts
+++ b/src/dash-table/components/Table/derivedPropsHelper.ts
@@ -61,7 +61,7 @@ export default () => {
         let newProps: Partial<SanitizedAndDerivedProps> = {};
 
         if (!derivedStructureCache.cached) {
-            newProps.derived_filter_structure = derivedStructureCache.result;
+            newProps.derived_filter_query_structure = derivedStructureCache.result;
         }
 
         if (!virtualCached) {

--- a/src/dash-table/components/Table/props.ts
+++ b/src/dash-table/components/Table/props.ts
@@ -391,7 +391,7 @@ interface IDefaultProps {
 }
 
 interface IDerivedProps {
-    derived_filter_structure: object | null;
+    derived_filter_query_structure: object | null;
     derived_viewport_data: Data;
     derived_viewport_indices: Indices;
     derived_viewport_row_ids: RowId[];


### PR DESCRIPTION
## About

The prop `derived_filter_query_structure` (https://github.com/plotly/dash-table/blob/dev/src/dash-table/dash/DataTable.js#L1149) was not triggering callbacks when `filter_query` changed. Updating the prop name in `derivedPropsHelper` (https://github.com/plotly/dash-table/blob/dev/src/dash-table/components/Table/derivedPropsHelper.ts#L64) fixed this. 