### PR TITLE
Fix 'child in a list should have a unique key prop'

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -5,8 +5,8 @@
     </head>
     <body>
         <div id='root'></div>
-        <script src='https://unpkg.com/react@16.8.6/umd/react.production.min.js'></script>
-        <script src='https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js'></script>
+        <script src='https://unpkg.com/react@16.8.6/umd/react.development.js'></script>
+        <script src='https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js'></script>
 
         <script src="./demo.js"></script>
     </body>

--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -859,7 +859,7 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
                     >
                         {arrayMap3(row, gridStyle[rowIndex], fragmentClasses[rowIndex], (g, s, c, columnIndex) => (<div
                             style={s.fragment}
-                            key={columnIndex}
+                            key={`row--${rowIndex}--column--${columnIndex}`}
                             ref={`r${rowIndex}c${columnIndex}`}
                             className={`cell cell-${rowIndex}-${columnIndex} ${c}`}
                         >

--- a/src/dash-table/derived/cell/contents.tsx
+++ b/src/dash-table/derived/cell/contents.tsx
@@ -143,7 +143,7 @@ class Contents {
         switch (cellType) {
             case CellType.Dropdown:
                 return (<CellDropdown
-                    key={`column-${columnIndex}`}
+                    key={`dp-row-${rowIndex}-column-${columnIndex}`}
                     active={active}
                     applyFocus={applyFocus}
                     clearable={dropdown && dropdown.clearable}
@@ -154,7 +154,7 @@ class Contents {
                 />);
             case CellType.Input:
                 return (<CellInput
-                    key={`column-${columnIndex}`}
+                    key={`ci-row-${rowIndex}-column-${columnIndex}`}
                     active={active}
                     applyFocus={applyFocus}
                     className={className}
@@ -167,6 +167,7 @@ class Contents {
                 />);
             case CellType.Markdown:
                 return (<CellMarkdown
+                    key={`cm-row-${rowIndex}-column-${columnIndex}`}
                     active={active}
                     applyFocus={applyFocus}
                     className={className}
@@ -183,7 +184,7 @@ class Contents {
                     active={active}
                     applyFocus={applyFocus}
                     className={className}
-                    key={`column-${columnIndex}`}
+                    key={`cl-row-${rowIndex}-column-${columnIndex}`}
                     value={resolvedValue}
                 />);
         }

--- a/src/dash-table/derived/cell/wrappers.tsx
+++ b/src/dash-table/derived/cell/wrappers.tsx
@@ -113,7 +113,7 @@ class Wrappers {
             'data-dash-row': rowIndex
         }}
         classes={classes}
-        key={`column-${columnIndex}`}
+        key={`row-${rowIndex}-column-${columnIndex}`}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
         onMouseEnter={onEnter}

--- a/src/dash-table/derived/header/wrappers.tsx
+++ b/src/dash-table/derived/header/wrappers.tsx
@@ -27,7 +27,7 @@ function getter(
                 }
 
                 return (<th
-                    key={`header-cell-${columnIndex}`}
+                    key={`header-cell-${columnIndex}--${column.id}`}
                     data-dash-column={column.id}
                     colSpan={colSpan}
                     className={


### PR DESCRIPTION
- Each element of a react list should have a unique key prop. This
is not the case here, as the key of a cell is generated from its
column index. To have unique key, we should use the row and column
index.

- The ./demo folder, should use the development version of react
(at least when you are developing ), otherwise React will NOT
show errors/warnings. This is very confusing, as the ./demo folder
is used for development purposes. The only way to see the react
warning was to change the script tags to point to the development
bundle of react. We should point to the correct bundle (e.g, if
NODE_ENV is set up to DEVELOPMENT, load the DEV bundle, if NODE_ENV
is set up to PRODUCTION, load the PRODUCTION bundle )

- I still get this error in the demo, but not in my component. I
guess there are some places where the keys are still not unique.
I was not able to find them in the dev tools and did not dig
thru the code too much