### PR TITLE
remove '#' from stylesheet id

### DIFF
--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -50,7 +50,7 @@ const INNER_STYLE = {
 
 export default class ControlledTable extends PureComponent<ControlledTableProps> {
     private readonly menuRef = React.createRef<HTMLDivElement>();
-    private readonly stylesheet: Stylesheet = new Stylesheet(`#${this.props.id}`);
+    private readonly stylesheet: Stylesheet = new Stylesheet(this.props.id);
     private readonly tableFn = derivedTable(() => this.props);
     private readonly tableFragments = derivedTableFragments();
     private readonly tableStyle = derivedTableStyle();


### PR DESCRIPTION
Just cleaning up a funny look - I'm assuming the `#` in the id wasn't intentional?
<img width="859" alt="Screen Shot 2020-03-02 at 6 23 47 PM" src="https://user-images.githubusercontent.com/2678795/75727532-26518700-5cb3-11ea-80f6-3488258e983b.png">
