### PR TITLE
Contribute basic examples to dashTable package for R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.6.1] - 2020-02-27
+### Added
+- [#711](https://github.com/plotly/dash-table/pull/711) Added R examples to package help
+
 ### Changed
 - [#704](https://github.com/plotly/dash-table/pull/704) Renamed async modules with hyphen `-` instead of tilde `~`
 

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -8,3 +8,71 @@ pkg_help_description: >-
     properties.
 pkg_help_title: >-
     Core Interactive Table Component for Dash
+r_examples:
+    - name: dashDataTable 
+      dontrun: TRUE 
+      code: |
+            # For comprehensive documentation of this package's features,
+            # please consult https://dashr.plot.ly/datatable
+            #
+            # A package vignette is currently in development and will
+            # provide many of the same examples currently available online
+            # in an offline-friendly format.
+            library(dash)
+            library(dashTable)
+
+            app <- Dash$new()
+
+            # We can easily restrict the number of rows to display at
+            # once by using style_table:
+            app$layout(
+              dashDataTable(
+                id = "table",
+                columns = lapply(colnames(iris), 
+                                 function(colName){
+                                   list(
+                                     id = colName,
+                                     name = colName
+                                   )
+                                 }),
+                style_table = list(
+                  maxHeight = "250px",
+                  overflowY = "scroll"
+                ),
+                data = df_to_list(iris)
+              )
+            )
+
+            app$run_server()
+
+            app <- Dash$new()
+
+            # We can also make rows and columns selectable/deletable
+            # by setting a few additional attributes:
+            app$layout(
+              dashDataTable(
+                id = "table",
+                columns = lapply(colnames(iris), 
+                                 function(colName){
+                                   list(
+                                     id = colName,
+                                     name = colName,
+                                     deletable = TRUE
+                                   )
+                                 }),
+                style_table = list(
+                  maxHeight = "250px",
+                  overflowY = "scroll"
+                ),
+                data = df_to_list(iris),
+                editable = TRUE,
+                filter_action = "native",
+                sort_action = "native",
+                sort_mode = "multi",
+                column_selectable = "single",
+                row_selectable = "multi",
+                row_deletable = TRUE
+              )
+            )
+
+            app$run_server()


### PR DESCRIPTION
This PR proposes to add two simple examples to the `dashTable` package, which is suggested for CRAN submission. A vignette will eventually be included with far more relevant information, but this should be enough to get people going.