### PR TITLE
Issue 651 - Clarify optional nature of row_id in active_cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#722](https://github.com/plotly/dash-table/pull/722) Fix a bug where row height is misaligned when using fixed_columns and/or fixed_rows
 - [#728](https://github.com/plotly/dash-table/pull/728) Fix copy/paste on readonly cells
+- [#724](https://github.com/plotly/dash-table/pull/724) Fix `active_cell` docstring: clarify optional nature of the `row_id` nested prop
 
 ## [4.6.2] - 2020-04-01
 ### Changed

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -110,7 +110,8 @@ export const defaultProps = {
 
 export const propTypes = {
     /**
-     * The row and column indices and IDs of the currently active cell.
+     * The row and column indices and IDs of the currently active cell. 
+     * `row_id` is only returned if the data rows have an `id` key.
      */
     active_cell: PropTypes.exact({
         row: PropTypes.number,


### PR DESCRIPTION
Closes #651 by making it clear in the documentation for `active_cell` that `row_id` only appears when row IDs are defined, by the user.

Did confuse me for a while at least.