### PR TITLE
Issue 526 - Copy/paste does not work in certain situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#728](https://github.com/plotly/dash-table/pull/728) Fix copy/paste on readonly cells
+
 ## [4.6.2] - 2020-04-01
 ### Changed
 - [#713](https://github.com/plotly/dash-table/pull/713) Update from React 16.8.6 to 16.13.0

--- a/src/dash-table/components/CellLabel/index.tsx
+++ b/src/dash-table/components/CellLabel/index.tsx
@@ -44,6 +44,7 @@ export default class CellLabel extends PureComponent<IProps> {
         const el = this.refs.el as HTMLDivElement;
 
         if (applyFocus && el && document.activeElement !== el) {
+            window.getSelection()?.selectAllChildren(el);
             el.focus();
         }
     }

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -410,13 +410,6 @@
                     position: absolute;
                     left: 0;
                     top: 0;
-
-                    &.unfocused::selection {
-                        background-color: transparent;
-                    }
-                    &.unfocused {
-                        caret-color: transparent;
-                    }
                 }
 
                 .cell-value-shadow {

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -396,6 +396,14 @@
                 .dash-cell-value {
                     height: 100%;
                     width: 100%;
+
+                    &.unfocused::selection {
+                        background-color: transparent;
+                    }
+
+                    &.unfocused {
+                        caret-color: transparent;
+                    }
                 }
 
                 input.dash-cell-value {

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -173,10 +173,10 @@
 	    &::placeholder {
 		color: black;
 	    }
-	    
+
 	    &:focus {
 		outline: none;
-		
+
 		&::placeholder {
 		    opacity: 0;
 		}
@@ -193,7 +193,7 @@
 
 	    &:hover {
 		color: hotpink;
-		
+
 		&:disabled {
 		    color: graytext
 		}
@@ -204,7 +204,7 @@
 	    }
 	}
     }
-    
+
     .dash-spreadsheet-container {
 	.reset-css();
 	display: flex;
@@ -365,20 +365,22 @@
 		}
 
 		.dash-cell-value {
-                    height: 100%;
-                    width: 100%;
+            height: 100%;
+            width: 100%;
+
+            &.unfocused::selection {
+			    background-color: transparent;
+            }
+
+            &.unfocused {
+			    caret-color: transparent;
+            }
 		}
 
 		input.dash-cell-value {
                     position: absolute;
                     left: 0;
                     top: 0;
-                    &.unfocused::selection {
-			background-color: transparent;
-                    }
-                    &.unfocused {
-			caret-color: transparent;
-                    }
 		}
 
 		.cell-value-shadow {


### PR DESCRIPTION
Closes #526 
Closes #676 

This allows readonly cells to trigger a `copy` event in the table. This PR forces content selection, restyling selection so as to not show, and makes sure the cell content has focus.

Due to overrides necessary for Selenium and Cypress to behave correctly with copy/paste inside the table, it is not possible to automate this test. It has been documented in the manual tests section of https://github.com/plotly/dash-core/blob/master/Manual%20Testing.md