### PR TITLE
Issue 486 - Don't scroll menu into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#722](https://github.com/plotly/dash-table/pull/722) Fix a bug where row height is misaligned when using fixed_columns and/or fixed_rows
 - [#728](https://github.com/plotly/dash-table/pull/728) Fix copy/paste on readonly cells
-the table down its last row
 - [#724](https://github.com/plotly/dash-table/pull/724) Fix `active_cell` docstring: clarify optional nature of the `row_id` nested prop
-- [#732](https://github.com/plotly/dash-table/pull/732) Fix a bug where opening a dropdown scrolled
+- [#732](https://github.com/plotly/dash-table/pull/732) Fix a bug where opening a dropdown scrolled the table down its last row
 
 ## [4.6.2] - 2020-04-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#732](https://github.com/plotly/dash-table/pull/732) Fix a bug where opening a dropdown scrolled
+the table down its last row
+
 ## [4.6.2] - 2020-04-01
 ### Changed
 - [#713](https://github.com/plotly/dash-table/pull/713) Update from React 16.8.6 to 16.13.0

--- a/src/dash-table/components/CellDropdown/index.tsx
+++ b/src/dash-table/components/CellDropdown/index.tsx
@@ -43,6 +43,7 @@ export default class CellDropdown extends PureComponent<IProps> {
                 onChange={(newValue: any) => {
                     onChange(newValue ? newValue.value : newValue);
                 }}
+                scrollMenuIntoView={false}
                 onOpen={this.handleOpenDropdown}
                 options={dropdown}
                 placeholder={''}

--- a/src/dash-table/components/CellDropdown/index.tsx
+++ b/src/dash-table/components/CellDropdown/index.tsx
@@ -43,7 +43,6 @@ export default class CellDropdown extends PureComponent<IProps> {
                 onChange={(newValue: any) => {
                     onChange(newValue ? newValue.value : newValue);
                 }}
-                scrollMenuIntoView={false}
                 onOpen={this.handleOpenDropdown}
                 options={dropdown}
                 placeholder={''}

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -101,6 +101,11 @@ class DataTableCellFacade(object):
 
         return "focused" in cell.get_attribute("class").split(" ")
 
+    def open_dropdown(self):
+        cell = self.get()
+
+        cell.find_element_by_css_selector(".Select-arrow").click()
+
 
 class DataTableColumnFacade(object):
     @preconditions(_validate_id, _validate_mixin, _validate_col_id, _validate_state)

--- a/tests/selenium/test_dropdown.py
+++ b/tests/selenium/test_dropdown.py
@@ -1,0 +1,51 @@
+import dash
+
+from dash_table import DataTable
+
+
+def get_app():
+    app = dash.Dash(__name__)
+
+    columns = [
+        dict(id="a", name="a"),
+        dict(id="b", name="b"),
+        dict(id="c", name="c", presentation="dropdown"),
+    ]
+
+    app.layout = DataTable(
+        id="table",
+        columns=columns,
+        dropdown=dict(
+            c=dict(
+                options=[
+                    dict(label="Value-0", value=0),
+                    dict(label="Value-1", value=1),
+                    dict(label="Value-2", value=2),
+                    dict(label="Value-3", value=3),
+                ]
+            )
+        ),
+        data=[dict(a=i, b=i, c=i % 4) for i in range(100)],
+        editable=True,
+    )
+
+    return app
+
+
+def get_page_offset(test):
+    return test.driver.execute_script(
+        "return document.body.getBoundingClientRect().top;"
+    )
+
+
+def test_drpd001_no_scroll(test):
+    test.start_server(get_app())
+
+    target = test.table("table")
+    cell = target.cell(1, "c")
+
+    yOffset = get_page_offset(test)
+
+    cell.open_dropdown()
+
+    assert get_page_offset(test) == yOffset


### PR DESCRIPTION
Closes #486 
Closes #672 

It seems that this was probably always broken.

Failing test run prior to fix: https://circleci.com/gh/plotly/dash-table/18036
Passing test run with the fix: https://circleci.com/gh/plotly/dash-table/18044