### PR TITLE
Update Rd file for df_to_list for CRAN

### DIFF
--- a/man/df_to_list.Rd
+++ b/man/df_to_list.Rd
@@ -17,8 +17,11 @@ df_to_list(df=NULL)
 \item{df}{A \code{data.frame} object, which will be transformed into a list of lists. Each row will become a single named list, in which the elements are named as the columns from which they were extracted.}
 }
 
+\value{
+a \code{list} object, in which the sublists are named elements of varying type; the names correspond to the column names in the \code{data.frame} specified by \code{df}.
+}
+
 \examples{
-\dontrun{
 # first, create data frame
 df <- read.csv(url(
   'https://raw.githubusercontent.com/plotly/datasets/master/solar.csv'
@@ -37,5 +40,4 @@ dashDataTable(
   }),
   data = df_to_list(df)
 )
-}
 }


### PR DESCRIPTION
This PR proposes to make the `df_to_list` example runnable for CRAN submission, and to add a `\value` tag, which they have also requested.

This should merge into `master`, since `df_to_list` does not exist in `dev`.