### PR TITLE
Fix usage entry within df_to_list.Rd

### DIFF
--- a/man/df_to_list.Rd
+++ b/man/df_to_list.Rd
@@ -10,7 +10,7 @@ Convert a \code{\link{data.frame}} to a list of lists for compatibility with \co
 }
 
 \usage{
-df_to_list(df=NULL)
+df_to_list(df)
 }
 
 \arguments{


### PR DESCRIPTION
This PR proposes to eliminate `=NULL` from the `\usage` block within `df_to_list.Rd`. Currently, there is a minor discrepancy between the documented usage and the actual usage, which causes the following error to occur upon running `R CMD check --as-cran`:

```
* checking for code/documentation mismatches ... WARNING
Codoc mismatches from documentation object 'df_to_list':
df_to_list
  Code: function(df)
  Docs: function(df = NULL)
  Mismatches in argument default values:
    Name: 'df' Code:  Docs: NULL
```