### PR TITLE
added className and text properties to DataTable to style export button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED]
 ### Fixed
 - [#854](https://github.com/plotly/dash-table/pull/854) - part of fixing dash import bug https://github.com/plotly/dash/issues/1143
+### Added
+- [#799](https://github.com/plotly/dash-table/pull/799) Added export_className and export_text
+  to modify class and text of the export button
 
 ## [4.11.1] - 2020-12-07
 ### Fixed

--- a/src/dash-table/components/ControlledTable/index.tsx
+++ b/src/dash-table/components/ControlledTable/index.tsx
@@ -965,6 +965,8 @@ export default class ControlledTable extends PureComponent<
             export_columns,
             export_format,
             export_headers,
+            export_className,
+            export_text,
             virtual,
             merge_duplicate_headers,
             paginator,
@@ -978,6 +980,8 @@ export default class ControlledTable extends PureComponent<
             columns,
             visibleColumns,
             export_headers,
+            export_className,
+            export_text,
             merge_duplicate_headers
         };
 

--- a/src/dash-table/components/Export/index.tsx
+++ b/src/dash-table/components/Export/index.tsx
@@ -16,6 +16,8 @@ interface IExportButtonProps {
     virtual_data: IDerivedData;
     visibleColumns: Columns;
     export_headers: ExportHeaders;
+    export_className?: string;
+    export_text?: string;
     merge_duplicate_headers: boolean;
 }
 
@@ -27,6 +29,8 @@ export default React.memo((props: IExportButtonProps) => {
         virtual_data,
         export_headers,
         visibleColumns,
+        export_className,
+        export_text,
         merge_duplicate_headers
     } = props;
     const isFormatSupported =
@@ -57,13 +61,9 @@ export default React.memo((props: IExportButtonProps) => {
         await exportWorkbook(wb, export_format);
     };
 
-    return (
-        <div>
-            {!isFormatSupported ? null : (
-                <button className='export' onClick={handleExport}>
-                    Export
-                </button>
-            )}
-        </div>
-    );
+    return (<div>
+        {!isFormatSupported ? null : (
+            <button className={export_className} onClick={handleExport}>{export_text}</button>
+        )}
+    </div>);
 });

--- a/src/dash-table/components/Table/props.ts
+++ b/src/dash-table/components/Table/props.ts
@@ -366,6 +366,9 @@ export interface IProps {
     virtualization?: boolean;
 
     loading_state?: ILoadingState;
+
+    export_text?: string;
+    export_className?: string;
 }
 
 interface IDefaultProps {

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -85,6 +85,8 @@ export const defaultProps = {
     editable: false,
     export_columns: 'visible',
     export_format: 'none',
+    export_className: 'export',
+    export_text: 'Export',
     include_headers_on_copy_paste: false,
     selected_cells: [],
     selected_columns: [],

--- a/src/dash-table/dash/DataTable.js
+++ b/src/dash-table/dash/DataTable.js
@@ -536,6 +536,18 @@ export const propTypes = {
     export_headers: PropTypes.oneOf(['none', 'ids', 'names', 'display']),
 
     /**
+     * Denotes the text of the export button
+     * Defaults to `'Export'`
+     */
+    export_text: PropTypes.string,
+
+    /**
+     * Denotes the class name of the export button
+     * Defaults to `'export'`
+     */
+    export_className: PropTypes.string,
+
+    /**
      * `fill_width` toggles between a set of CSS for two common behaviors:
      * True: The table container's width will grow to fill the available space;
      * False: The table container's width will equal the width of its content.

--- a/tests/selenium/test_export_button.py
+++ b/tests/selenium/test_export_button.py
@@ -1,0 +1,31 @@
+import os
+import pandas as pd
+import dash_table
+import dash
+import dash.testing.wait as wait
+
+
+def test_tbex002_export_button(dash_duo):
+    df = pd.read_csv(
+        "https://raw.githubusercontent.com/plotly/datasets/master/solar.csv"
+    )
+    app = dash.Dash(__name__)
+    app.layout = dash_table.DataTable(
+        id="table",
+        columns=[{"name": i, "id": i} for i in df.columns],
+        data=df.to_dict("records"),
+        export_format="csv",
+        export_className="veryuniqueexportclassname",
+        export_text="veryuniqueexporttext",
+    )
+    dash_duo.start_server(app)
+    export_button = dash_duo.wait_for_element(".veryuniqueexportclassname", timeout=1)
+    assert export_button.text == "veryuniqueexporttext"
+
+    export_button.click()
+
+    download = os.path.sep.join((dash_duo.download_path, "Data.csv"))
+    wait.until(lambda: os.path.exists(download), timeout=2)
+
+    df_bis = pd.read_csv(download)
+    assert df_bis.equals(df)

--- a/tests/visual/percy-storybook/DashTable.percy.tsx
+++ b/tests/visual/percy-storybook/DashTable.percy.tsx
@@ -382,4 +382,11 @@ storiesOf('DashTable/Export', module)
         data={dataA2J.slice(0, 10)}
         columns={columnsA2J.slice(0, 10)}
         export_format={ExportFormat.None}
+    />))
+    .add('Export Button with different text', () => (<DataTable
+        setProps={setProps}
+        data={dataA2J.slice(0, 10)}
+        columns={columnsA2J.slice(0, 10)}
+        export_format={ExportFormat.Xlsx}
+        export_text="Export with Love"
     />));


### PR DESCRIPTION
This PR adds two props for the DataTable, `export_className` and `export_text`.  This allows to modify the class and the text of the export button. Very useful if you want to style the button with e.g. bootstrap classes or translate the button text.

### Pre-Merge checklist
- [ ] All tests on CircleCI have passed.
- [ ] All visual regression differences have been approved.
- [x] You have added an entry describing the change at the the top of `CHANGELOG.md`. The entry should also link to the original pull request(s).
- [ ] Two Dash core contributors have :dancer:'d the pull request.

### Post-Merge checklist
- [ ] You have deleted the branch.
- [ ] You have closed all issues that this pull request solves.
- [ ] If significant enough, you have created an issue about documenting the new feature or change and you have added it to the [dash-docs](https://github.com/plotly/dash-docs) project.
