### PR TITLE
Update `dash-info.yaml`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,6 +19,10 @@ lib/
 demo/.*\.js
 demo/.*\.html
 demo/.*\.css
+demo/.*\.ts
+demo/.*\.tsx
+demo/.*\.less
+
 
 # ignore Python files/folders
 setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - New props: `filter_options` - to control case of all filters, `columns.filter_options` - to control filter case for each column
     - New operators: `i=`, `ieq`, `i>=`, `ige`, `i>`, `igt`, `i<=`, `ile`, `i<`, `ilt`, `i!=`, `ine`, `icontains` - for case-insensitive filtering, `s=`, `seq`, `s>=`, `sge`, `s>`, `sgt`, `s<=`, `sle`, `s<`, `slt`, `s!=`, `sne`, `scontains` - to force case-sensitive filtering on case-insensitive columns
 
+### Changed
+- [#901](https://github.com/plotly/dash-core-components/pull/901) Updated R package `dash-info.yaml` to re-generate examples without loading add-on packages.
+
 ## [4.11.3] - 2021-04-08
 ### Changed
 - [#862](https://github.com/plotly/dash-table/pull/862) - update docstrings per https://github.com/plotly/dash/issues/1205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - New operators: `i=`, `ieq`, `i>=`, `ige`, `i>`, `igt`, `i<=`, `ile`, `i<`, `ilt`, `i!=`, `ine`, `icontains` - for case-insensitive filtering, `s=`, `seq`, `s>=`, `sge`, `s>`, `sgt`, `s<=`, `sle`, `s<`, `slt`, `s!=`, `sne`, `scontains` - to force case-sensitive filtering on case-insensitive columns
 
 ### Changed
-- [#901](https://github.com/plotly/dash-core-components/pull/901) Updated R package `dash-info.yaml` to re-generate examples without loading add-on packages.
+- [#901](https://github.com/plotly/dash-core-components/pull/901) Updated R package `dash-info.yaml` to regenerate example without attaching now-deprecated core component packages (`dashHtmlComponents`, `dashCoreComponents`, or `dashTable`).
 
 ## [4.11.3] - 2021-04-08
 ### Changed

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -4,12 +4,12 @@ pkg_help_description: >-
     <table/> markup, which makes it accessible, responsive, and easy
     to style. This component was written from scratch in 'React.js'
     specifically for the 'Dash' community. Its API was designed to be
-    ergonomic and its behaviour is completely customizable through its 
+    ergonomic and its behaviour is completely customizable through its
     properties.
 pkg_help_title: >-
     Core Interactive Table Component for 'Dash'
 pkg_authors: >-
-    c(person("Chris", "Parmer", email = "chris@plotly.com", role = c("aut")), person("Ryan Patrick", "Kyle", email = "ryan@plotly.com", role = c("cre"), comment = c(ORCID = "0000-0002-4958-2844")), person(family = "Plotly Technologies, Inc.", role = "cph")) 
+    c(person("Chris", "Parmer", email = "chris@plotly.com", role = c("aut")), person("Ryan Patrick", "Kyle", email = "ryan@plotly.com", role = c("cre"), comment = c(ORCID = "0000-0002-4958-2844")), person(family = "Plotly Technologies, Inc.", role = "cph"))
 pkg_copyright: >-
     Plotly Technologies, Inc.
 r_examples:
@@ -28,7 +28,6 @@ r_examples:
             # maintainers.
             if (interactive() && require(dash)) {
               library(dash)
-              library(dashTable)
 
               app <- Dash$new()
 
@@ -53,7 +52,7 @@ r_examples:
               )
 
               app$run_server()
-              
+
               app <- Dash$new()
 
               # We can also make rows and columns selectable/deletable


### PR DESCRIPTION
This PR updates `dash-info.yaml` to re-generate R examples in consistency with the Dash R monopackage update plotly/dashR#243.