### PR TITLE
Attempt to fix incorrect tooltip placement

### DIFF
--- a/src/dash-table/derived/table/tooltip.ts
+++ b/src/dash-table/derived/table/tooltip.ts
@@ -42,7 +42,7 @@ function getSelectedTooltip(
               return (
                   !tt.if ||
                   (ifColumnId(tt.if, id) &&
-                      ifRowIndex(tt.if, row) &&
+                      ifRowIndex(tt.if, virtualized.indices[row - virtualized.offset.rows]) &&
                       ifFilter(
                           tt.if,
                           virtualized.data[row - virtualized.offset.rows]

--- a/src/dash-table/handlers/cellEvents.ts
+++ b/src/dash-table/handlers/cellEvents.ts
@@ -165,13 +165,13 @@ export const handleEnter = (
     idx: number,
     i: number
 ) => {
-    const {setState, virtualized, visibleColumns} = propsFn();
+    const {setState, visibleColumns} = propsFn();
 
     setState({
         currentTooltip: {
             header: false,
             id: visibleColumns[i].id,
-            row: virtualized.indices[idx - virtualized.offset.rows]
+            row: idx
         }
     });
 };
@@ -207,15 +207,14 @@ export const handleMove = (
     idx: number,
     i: number
 ) => {
-    const {currentTooltip, setState, virtualized, visibleColumns} = propsFn();
+    const {currentTooltip, setState, visibleColumns} = propsFn();
 
     const c = visibleColumns[i];
-    const realIdx = virtualized.indices[idx - virtualized.offset.rows];
 
     if (
         currentTooltip &&
         currentTooltip.id === c.id &&
-        currentTooltip.row === realIdx &&
+        currentTooltip.row === idx &&
         !currentTooltip.header
     ) {
         return;
@@ -225,7 +224,7 @@ export const handleMove = (
         currentTooltip: {
             header: false,
             id: c.id,
-            row: realIdx
+            row: idx
         }
     });
 };


### PR DESCRIPTION
This is an attempt to fix #872, the interpretation of the row value of currentTooltip was inconsistent across the codebase. In this patch I try to fix the row value to mean the row in the current displayed data which means that getSelectedTooltip needs to convert to the row number of the full dataset. It works for filtering and pagination in the demo application. However I have not tested with a proper virtualized dataset.

I have little to no experience with javascript, typescript or developing dash components so there is a great risk that I have overlooked something trivial.

Thank you very much for an amazing tool in dash table.