### PR TITLE
issue #834 fix when pagination doesn't work when more than one table …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [#907](https://github.com/plotly/dash-table/pull/907) Fix a bug where pagination did not work or was not visible. [#834](https://github.com/plotly/dash-table/issues/834)
+
+
+
 ### Added
 - [#545](https://github.com/plotly/dash-table/issues/545)
     - Case insensitive filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- [#907](https://github.com/plotly/dash-table/pull/907) Fix a bug where pagination did not work or was not visible. [#834](https://github.com/plotly/dash-table/issues/834)
-
+- [#907](https://github.com/plotly/dash-table/pull/907) 
+  - Fix a bug where pagination did not work or was not visible. [#834](https://github.com/plotly/dash-table/issues/834)
+  - Fix a bug where if you are on a page that no longer exists after the data is updated, no data is displayed. [#892](https://github.com/plotly/dash-table/issues/892)
 
 
 ### Added

--- a/src/dash-table/components/Table/Table.less
+++ b/src/dash-table/components/Table/Table.less
@@ -143,7 +143,7 @@
 
 .dash-table-container {
     .previous-next-container {
-        float: right;
+        text-align: right;
         padding: 5px 0px;
 
         .page-number {

--- a/src/dash-table/derived/paginator.ts
+++ b/src/dash-table/derived/paginator.ts
@@ -50,6 +50,11 @@ function makePaginator(params: IPaginatorParams | null): IPaginator {
     const {setProps, page_count} = params;
     let {page_current} = params;
 
+    if (page_count && page_count - 1 < page_current) {
+        page_current = 0;
+        updatePage();
+    }
+
     function updatePage() {
         setProps({
             page_current,

--- a/tests/selenium/test_pagination.py
+++ b/tests/selenium/test_pagination.py
@@ -2,6 +2,7 @@ import dash
 from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
 import dash_html_components as html
+import dash_core_components as dcc
 
 from dash_table import DataTable
 
@@ -221,6 +222,7 @@ def get_app2():
                 data=[{"i": i, "square": i ** 2} for i in range(50 + 1)],
                 page_current=5,
             ),
+            dcc.Graph(),
         ]
     )
 
@@ -243,3 +245,11 @@ def test_tpag011_valid_page(test):
 
     assert target.paging.current.get_value() == "1"
     assert test.get_log_errors() == []
+
+
+def test_tpage012_pagination_row_visible(test):
+    test.start_server((get_app2()))
+
+    test.table("table").is_ready()
+
+    test.percy_snapshot("test_tpage012 Pagination row visible")

--- a/tests/selenium/test_pagination.py
+++ b/tests/selenium/test_pagination.py
@@ -246,10 +246,5 @@ def test_tpag011_valid_page(test):
     assert target.paging.current.get_value() == "1"
     assert test.get_log_errors() == []
 
-
-def test_tpage012_pagination_row_visible(test):
-    test.start_server((get_app2()))
-
     test.table("table").is_ready()
-
-    test.percy_snapshot("test_tpage012 Pagination row visible")
+    test.percy_snapshot("test_tpage011 Pagination row visible")

--- a/tests/selenium/test_pagination.py
+++ b/tests/selenium/test_pagination.py
@@ -247,4 +247,4 @@ def test_tpag011_valid_page(test):
     assert test.get_log_errors() == []
 
     test.table("table").is_ready()
-    test.percy_snapshot("test_tpage011 Pagination row visible")
+    test.percy_snapshot("test_tpag011 Pagination row visible")

--- a/tests/selenium/test_pagination.py
+++ b/tests/selenium/test_pagination.py
@@ -1,6 +1,7 @@
 import dash
 from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
+import dash_html_components as html
 
 from dash_table import DataTable
 
@@ -204,4 +205,41 @@ def test_tpag010_limits_page(test):
     target.paging.last.click()
 
     assert target.paging.current.get_value() == "10"
+    assert test.get_log_errors() == []
+
+
+def get_app2():
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.Button("i=20", id="button", n_clicks=0),
+            DataTable(
+                id="table",
+                page_size=5,
+                columns=[{"name": "i", "id": "i"}, {"name": "square", "id": "square"}],
+                data=[{"i": i, "square": i ** 2} for i in range(50 + 1)],
+                page_current=5,
+            ),
+        ]
+    )
+
+    @app.callback(Output("table", "data"), Input("button", "n_clicks"))
+    def update_table_data(n):
+        return (
+            [{"i": i, "square": i ** 2} for i in range(20 + 1)]
+            if n > 0
+            else dash.no_update
+        )
+
+    return app
+
+
+def test_tpag011_valid_page(test):
+    test.start_server(get_app2())
+
+    target = test.table("table")
+    test.find_element("#button").click()
+
+    assert target.paging.current.get_value() == "1"
     assert test.get_log_errors() == []


### PR DESCRIPTION
This PR fixes two pagination issues:
1) Where pagination buttons are not visible or do not work because another table or figure overlaps the pagination container.
    - Closes:  https://github.com/plotly/dash-docs/pull/1150
    - Fixes https://github.com/plotly/dash-table/issues/834
    - Fixes #739 
    - Fixes #727 


2) If you are on a page that no longer exists after data is updated, then no data shows in the table.  This is fixed by resetting the `page_current` to 0
    - Fixes #892 
    - Fixes #698 
    - Fixes #782
    - Fixes #635 

---------------------
-------------------


__Pagination buttons now work in the example from 834:__

![pagination](https://user-images.githubusercontent.com/72614349/120372498-1bc5d900-c2cc-11eb-87de-eca632b67028.gif)

--------
-----------

__Pagination buttons are are now visible here: https://dash.plotly.com/datatable/interactivity__
![image](https://user-images.githubusercontent.com/72614349/120372531-27b19b00-c2cc-11eb-8517-87be24a15db5.png)














