### PR TITLE
Fix the tooltip_conditional row indexing

### DIFF
--- a/src/dash-table/derived/table/tooltip.ts
+++ b/src/dash-table/derived/table/tooltip.ts
@@ -45,7 +45,7 @@ function getSelectedTooltip(
                       ifRowIndex(tt.if, row) &&
                       ifFilter(
                           tt.if,
-                          virtualized.data[row - virtualized.offset.rows]
+                          virtualized.data[virtualized.indices.indexOf(row) - virtualized.offset.rows]
                       ))
               );
           }, tooltip_conditional);


### PR DESCRIPTION
This PR is to fix the bug reported in https://github.com/plotly/dash-table/issues/917-  tooltip_conditional filter cause "TypeError: Can not read property of undefined" exception when client side pagination is enabled.

When pagination is enabled, the virtualized.data array only contains rows in the current pages, but the row value passed to this function is the index relative to the whole table. 

To give a concrete example, suppose the page size = 4, and the whole table has 10 rows, and we are on the second page. Then virtualized.data will be a array of length 4 and contains the rows of the 2nd page;  virtualized.indices=[4, 5, 6, 7]; virtualized.offset.rows=0 (assuming not using virtualization mode). When we move the cursor over the first row in that page, the callback will be invoked with row=4.  The line in question will result in trying to access virtualized.data[4], which caused the exception. 

The fix instead looks up the virtualized.indices list to convert the row to the correct index relative to current page.

Actually, the bug can also manifest when filtering is on.