### PR TITLE
Handle null value safely in case-insensitive filter

### DIFF
--- a/src/dash-table/syntax-tree/lexeme/relational.ts
+++ b/src/dash-table/syntax-tree/lexeme/relational.ts
@@ -64,8 +64,11 @@ const fnEval = (
     relOp: string
 ): boolean =>
     relOp[0] == 'i'
-        ? fn(lhs.toString().toUpperCase(), rhs.toString().toUpperCase())
+        ? fn(safeToUpperCase(lhs), safeToUpperCase(rhs))
         : fn(lhs, rhs);
+
+const safeToUpperCase = (v: any): string =>
+    R.isNil(v) ? '' : v.toString().toUpperCase()
 
 export const contains: IUnboundedLexeme = R.merge(
     {


### PR DESCRIPTION
Fix the issue described in  https://github.com/plotly/dash-table/issues/934

Basically if the value is null, return empty string directly instead of call .toString()